### PR TITLE
Add thanos chart

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -109,10 +109,9 @@ spec:
         interval: TO_BE_FIXED
     kubeEtcd:
       enabled: true
-      serviceMonitor:
-        interval: TO_BE_FIXED
       endpoints: [] # TO_BE_FIXED
       serviceMonitor:
+        interval: TO_BE_FIXED
         caFile: /etc/prometheus/secrets/etcd-client-cert/etcd-ca
         certFile: /etc/prometheus/secrets/etcd-client-cert/etcd-client
         insecureSkipVerify: false
@@ -160,9 +159,18 @@ spec:
           matchLabels:
             name: lma
         serviceMonitorSelectorNilUsesHelmValues: false
+        thanos:
+          version: v0.11.0
       service:
         nodePort: 30008
         type: NodePort
+        additionalPorts:
+        - name: grpc
+          protocol: TCP
+          port: 10901
+          targetPort: grpc
+          nodePort: 30901
+
     prometheusOperator:
       admissionWebhooks:
         enabled: false
@@ -812,10 +820,6 @@ spec:
       alerts:
         makeAlertRule: true
       nodeSelector: {} # TO_BE_FIXED
-    fluentbitOperator:
-      enabled: false
-      createCustomResource: false
-      cleanupCustomResource: false
     logExporter:
       enabled: false
     image:
@@ -1028,4 +1032,124 @@ spec:
       targetPort: 32000
       type: NodePort
   wait: true
-
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: thanos
+  name: thanos
+spec:
+  helmVersion: v3
+  chart:
+    repository: https://charts.bitnami.com/bitnami
+    name: thanos
+    version: 3.4.0
+  releaseName: thanos
+  targetNamespace: fed
+  values:
+    global:
+      storageClass: local-path
+    clusterDomain: TO_BE_FIXED
+    objstoreConfig: TO_BE_FIXED
+    query:
+      nodeSelector: {}
+    querier:
+      stores: TO_BE_FIXED
+    queryFrontend:
+      nodeSelector: {}
+      service:
+        type: TO_BE_FIXED
+        http:
+          port: 9090
+          nodePort: TO_BE_FIXED
+    bucketweb:
+      enabled: true
+      logLevel: info
+      refresh: 30m
+      timeout: 5m
+      nodeSelector: {}
+      service:
+        type: ClusterIP
+        http:
+          port: 8080
+    compactor:
+      enabled: true
+      logLevel: info
+      retentionResolutionRaw: 30d
+      retentionResolution5m: 30d
+      retentionResolution1h: 10y
+      consistencyDelay: 30m
+      nodeSelector: {}
+      service:
+        type: ClusterIP
+        http:
+          port: 9090
+      persistence:
+        enabled: true
+        accessModes:
+          - ReadWriteOnce
+        size: TO_BE_FIXED
+    storegateway:
+      enabled: true
+      logLevel: info
+      nodeSelector: {}
+      service:
+        type: ClusterIP
+        http:
+          port: 9090
+        grpc:
+          port: 10901
+      persistence:
+        enabled: true
+        accessModes:
+          - ReadWriteOnce
+        size: TO_BE_FIXED
+      autoscaling:
+        enabled: false
+        #  minReplicas: 1
+        #  maxReplicas: 11
+        #  targetCPU: 50
+        #  targetMemory: 50
+    ruler:
+      enabled: true
+      logLevel: info
+      alertmanagers: TO_BE_FIXED
+      evalInterval: 1m
+      config: TO_BE_FIXED
+      replicaCount: 1
+      updateStrategyType: RollingUpdate
+      podManagementPolicy: OrderedReady
+      nodeSelector: {}
+      service:
+        type: ClusterIP
+        http:
+          port: 9090
+        grpc:
+          port: 10901
+      persistence:
+        enabled: true
+        accessModes:
+          - ReadWriteOnce
+        size: TO_BE_FIXED
+    metrics:
+      enabled: false
+      serviceMonitor:
+        enabled: false
+    volumePermissions:
+      enabled: false
+      image:
+        registry: docker.io
+        repository: bitnami/minideb
+        tag: buster
+    minio:
+      enabled: true
+      accessKey:
+        password: TO_BE_FIXED
+      secretKey:
+        password: TO_BE_FIXED
+      defaultBuckets: TO_BE_FIXED
+      service:
+        type: NodePort
+        nodePort: 30002
+  wait: true

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -10,6 +10,8 @@ global:
   storageClassName: ceph
   serviceScrapeInterval: 10s
   federateScrapeInterval: 10s
+  defaultPassword: password
+  defaultUser: taco
 
 charts:
 - name: prometheus-operator
@@ -153,3 +155,39 @@ charts:
   override:
     conf.default.hosts:
     - TO_BE_FIXED
+
+- name: thanos
+  override:
+    global.storageClass: $(storageClassName)
+    clusterDomain: cluster.local
+    objstoreConfig: |-
+      type: s3
+      config:
+        bucket: thanos
+        endpoint: {{ include "thanos.minio.fullname" . }}.fed.svc.$(clusterName):9000
+        access_key: $(defaultUser)
+        secret_key: $(defaultPassword)
+        insecure: true
+    query.nodeSelector: $(nodeSelector)
+    queryFrontend.nodeSelector: $(nodeSelector)
+    queryFrontend.service.type: NodePort
+    queryFrontend.service.http.nodePort: 30007
+    bucketweb.nodeSelector: $(nodeSelector)
+    compactor.nodeSelector: $(nodeSelector)
+    storegateway.nodeSelector: $(nodeSelector)
+    ruler.nodeSelector: $(nodeSelector)      
+
+    compactor.persistence.size: 8Gi
+    storegateway.persistence.size: 8Gi
+    ruler.alertmanagers:
+      - http://prometheus-operator-alertmanager:9093
+    ruler.config: |-
+        groups:
+          - name: "metamonitoring"
+            rules:
+              - alert: "PrometheusDown"
+                expr: absent(up{prometheus="monitoring/prometheus-operator"})
+    ruler.persistence.size: 8Gi
+    minio.accessKey.password: $(defaultUser)
+    minio.secretKey.password: $(defaultPassword)
+    minio.defaultBuckets: 'thanos'


### PR DESCRIPTION
prometheus-thanos 지원하기위한 PR입니다.
이를 사용하면 thanos를 통해 멀티 클러스터 접근 가능합니다.
그외 다양한 기능도 사용할수 있도록 하였습니다.

구체적으로 적용하는 방법은
lma/site/site-values.yaml 를 참조하시기 바랍니다.

decapod에서는 workflow에 추가해서 사용가능 