### PR TITLE
Bump fluentbit-operator chart up to 1.0.10

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -560,7 +560,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: fluentbit-operator
-    version: 1.0.9
+    version: 1.0.10
     skipDepUpdate: true
   releaseName: fluentbit-operator
   targetNamespace: lma
@@ -603,7 +603,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: fluentbit-operator
-    version: 1.0.9
+    version: 1.0.10
     skipDepUpdate: true
   releaseName: fluentbit
   targetNamespace: lma


### PR DESCRIPTION
* fluentbit-operator chart를 1.0.10으로 업데이트
* 1.0.10버전에서는 fluentbit cr-cm과 job-es-template의 helm hook-delete-policy 관련 문제가 수정됨