### PR TITLE
add nodePort to elasticsearch

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -465,6 +465,15 @@ spec:
       adminPassword: TO_BE_FIXED
       enabled: true 
       count: 3        # FIXME
+      http:
+        service:
+          spec:
+            type: NodePort
+            ports:
+            - name: https
+              nodePort: 30002
+              targetPort: 9200
+              port: 9200
       nodeSets:
         master:
           enabled: true


### PR DESCRIPTION
* elasticsearch test를 위해 직접 elasticsearch와 통신이 필요함. 외부통신을 위한 nodePort를 open한다.