### PR TITLE
Fix render decapod-base-yaml

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,10 +9,10 @@
 $ git clone https://github.com/openinfradev/decapod-base-yaml.git
 
 $ # build lma
-$ docker run --rm -i -v decapod-base-yaml:/decapod-base-yaml sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /decapod-base-yaml/lma/base
+$ docker run --rm -i -v $(pwd)/decapod-base-yaml:/decapod-base-yaml sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /decapod-base-yaml/lma/base
 
 $ # build openstack
-$ docker run --rm -i -v decapod-base-yaml:/decapod-base-yaml sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /decapod-base-yaml/openstack
+$ docker run --rm -i -v $(pwd)/decapod-base-yaml:/decapod-base-yaml sktdev/decapod-kustomize:latest kustomize build --enable_alpha_plugins /decapod-base-yaml/openstack/base
 ```
 
 ## Render decapod-site-yaml


### PR DESCRIPTION
- decapod-base-yaml 볼륨 마운트 시 상대경로를 사용하면 에러가 발생. 절대경로로 변경
- openstack의 경우 base폴더가 빠져있어 이를 추가