### PR TITLE
bugfix: can't specify nodePort

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -469,11 +469,6 @@ spec:
         service:
           spec:
             type: NodePort
-            ports:
-            - name: https
-              nodePort: 30002
-              targetPort: 9200
-              port: 9200
       nodeSets:
         master:
           enabled: true


### PR DESCRIPTION
* es `9200` port는 hotdata, master, http가 공통으로 갖는다.
* http의 nodePort 30002로 세팅하고 싶지만 targetPort가 모두 9200으로 같아서 설정상 어떻게 해도 적용이 안되는 느낌.
* 따라서 type: NodePort로만 설정하면 다음과 같이 랜덤하게 nodePort가 잘 적용된다.
```
eck-elasticsearch-es-hotdata          ClusterIP   None            <none>        9200/TCP             30m
eck-elasticsearch-es-http             NodePort    10.233.5.88     <none>        9200:30928/TCP       16m
eck-elasticsearch-es-master           ClusterIP   None            <none>        9200/TCP             30m
```
* random 하게 설정된 nodePort를 가져오도록 validate-lma job을 수정함