### PR TITLE
Add service-mesh applications

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -863,7 +863,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.0.7
+    version: 1.0.8
   releaseName: addons
   targetNamespace: lma
   values:
@@ -898,6 +898,12 @@ spec:
       kubelet:
         enabled: true
         interval: TO_BE_FIXED
+      istio:
+        enabled: true
+        interval: TO_BE_FIXED
+      jaeger:
+        enabled: true
+        interval: TO_BE_FIXED
     tacoWatcher:
       rbac:
         create: false
@@ -914,7 +920,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.0.7
+    version: 1.0.8
   releaseName: fed-addons
   targetNamespace: fed
   values:
@@ -934,6 +940,10 @@ spec:
       sidecar:
         datasources:
           prometheusAddress: "fed-master-prometheus:9090"
+      istio:
+        enabled: true
+      jaeger:
+        enabled: true
     serviceMonitor:
       calico:
         enabled: false

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -863,7 +863,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.0.8
+    version: 1.1.0
   releaseName: addons
   targetNamespace: lma
   values:
@@ -920,7 +920,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.0.8
+    version: 1.1.0
   releaseName: fed-addons
   targetNamespace: fed
   values:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -125,6 +125,8 @@ charts:
     serviceMonitor.kubeStateMetrics.interval: $(serviceScrapeInterval)
     serviceMonitor.nodeExporter.interval: $(serviceScrapeInterval)
     serviceMonitor.kubelet.interval: $(serviceScrapeInterval)
+    serviceMonitor.istio.interval: $(serviceScrapeInterval)
+    serviceMonitor.jaeger.interval: $(serviceScrapeInterval)
 
 - name: fed-addons
   override:

--- a/service-mesh/base/kustomization.yaml
+++ b/service-mesh/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - resources.yaml
+
+transformers:
+  - site-values.yaml

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -90,8 +90,20 @@ spec:
         deployment:
           accessible_namespaces:
           - '**'
+        external_services:
+          custom_dashboards:
+            enabled: true
+          prometheus:
+            url: "http://lma-prometheus.lma:9090"
+          tracing:
+            enabled: true
+            url: "http://jaeger-operator-jaeger-query.lma:16686"
+            namespace_selector: true
+        istio_component_namespaces:
+          prometheus: lma
         auth:
           strategy: anonymous #openid, token, openshift, header, anonymous
+        istio_namespace: istio-namespace1
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -30,20 +30,41 @@ spec:
     name: jaeger-operator
     version: 2.19.1
   releaseName: jaeger-operator
-  targetNamespace: observability
+  targetNamespace: lma
   values:
-    jeager:
+    jaeger:
       create: true
-      namespace:
+      namespace: lma
       spec:
-        strategy: production
+        strategy: production # production, allInOne, streaming
         storage:
           type: elasticsearch
+          esIndexCleaner:
+            enabled: true
+            numberOfDays: 7
+            schedule: "55 04 * * *"
           options:
             es:
-              server-urls: https://eck-elasticsearch-es-http:9200
+              server-urls: TO_BE_FIXED
+              tls.ca: /etc/ssl/certs/tls.crt
               username: TO_BE_FIXED
               password: TO_BE_FIXED
+              index-prefix: jaeger
+        collector:
+          maxReplicas: 5
+          resources:
+            limits:
+              cpu: 300m
+              memory: 256Mi
+        agent:
+          strategy: Sidecar
+        volumeMounts:
+        - name: es-tls
+          mountPath: /etc/ssl/certs
+        volumes:
+        - name: es-tls
+          secret:
+            secretName: eck-elasticsearch-es-http-certs-public
       nodeSelector: {}
   wait: true
 ---
@@ -58,7 +79,7 @@ spec:
   chart:
     repository: https://jabbukka.github.io/helm-charts
     name: service-mesh-resource
-    version: 0.1.0
+    version: 0.1.1
   releaseName: service-mesh-resource
   targetNamespace: istio-system
   values:

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -1,0 +1,67 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: istio-operator
+  name: istio-operator
+spec:
+  helmVersion: v3
+  chart:
+    repository: https://openinfradev.github.io/hanu-helm-repo
+    name: istio-operator
+    version: 1.7.0
+  releaseName: istio-operator
+  targetNamespace: istio-system
+  values:
+    operatorNamespace: istio-operator
+    watchedNamespace: istio-system  # namespace list seperated with comma
+  wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: jaeger-operator
+  name: jaeger-operator
+spec:
+  helmVersion: v3
+  chart:
+    repository: https://jaegertracing.github.io/helm-charts
+    name: jaeger-operator
+    version: 2.19.1
+  releaseName: jaeger-operator
+  targetNamespace: observability
+  values:
+    jeager:
+      create: true
+      namespace:
+      spec:
+        strategy: production
+        storage:
+          type: elasticsearch
+          options:
+            es:
+              server-urls: https://eck-elasticsearch-es-http:9200
+              username: TO_BE_FIXED
+              password: TO_BE_FIXED
+      nodeSelector: {}
+  wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: service-mesh-resource
+  name: service-mesh-resource
+spec:
+  helmVersion: v3
+  chart:
+    repository: https://jabbukka.github.io/helm-charts
+    name: service-mesh-resource
+    version: 0.1.0
+  releaseName: service-mesh-resource
+  targetNamespace: istio-system
+  values:
+    enabled: true
+    profile: demo
+    istioNamespace: istio-namespace1

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -72,12 +72,39 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
+    name: kiali
+  name: kiali
+spec:
+  helmVersion: v3
+  chart:
+    repository: https://kiali.org/helm-charts
+    name: kiali-server
+    version: 1.29.0
+  releaseName: kiali
+  targetNamespace: istio-system
+  values:
+    auth:
+      strategy: anonymous
+    deployment:
+      pod_annotations:
+        sidecar.istio.io/inject: "false"
+      accessible_namespaces:
+      - '**'
+      image_version: v1.29
+      ingress_enabled: false
+    login_token:
+      signing_key: CHANGEME
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
     name: service-mesh-resource
   name: service-mesh-resource
 spec:
   helmVersion: v3
   chart:
-    repository: https://jabbukka.github.io/helm-charts
+    repository: https://openinfradev.github.io/hanu-helm-repo
     name: service-mesh-resource
     version: 0.1.1
   releaseName: service-mesh-resource

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -13,7 +13,7 @@ spec:
   releaseName: istio-operator
   targetNamespace: istio-system
   values:
-    operatorNamespace: istio-operator
+    operatorNamespace: istio-system
     watchedNamespace: istio-system  # namespace list seperated with comma
   wait: true
 ---
@@ -72,28 +72,26 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: kiali
-  name: kiali
+    name: kiali-operator
+  name: kiali-operator
 spec:
   helmVersion: v3
   chart:
     repository: https://kiali.org/helm-charts
-    name: kiali-server
-    version: 1.29.0
-  releaseName: kiali
+    name: kiali-operator
+    version: 1.30.0
+  releaseName: kiali-operator
   targetNamespace: istio-system
   values:
-    auth:
-      strategy: anonymous
-    deployment:
-      pod_annotations:
-        sidecar.istio.io/inject: "false"
-      accessible_namespaces:
-      - '**'
-      image_version: v1.29
-      ingress_enabled: false
-    login_token:
-      signing_key: CHANGEME
+    cr:
+      create: true
+      name: kiali
+      spec:
+        deployment:
+          accessible_namespaces:
+          - '**'
+        auth:
+          strategy: anonymous #openid, token, openshift, header, anonymous
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/service-mesh/base/site-values.yaml
+++ b/service-mesh/base/site-values.yaml
@@ -6,7 +6,7 @@ metadata:
 charts:
 - name: jaeger-operator
   override:
-    spec.storage.options.es:
+    jaeger.spec.storage.options.es:
       server-urls: https://eck-elasticsearch-es-http:9200
       username: elastic
       password: tacoword

--- a/service-mesh/base/site-values.yaml
+++ b/service-mesh/base/site-values.yaml
@@ -1,0 +1,12 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: site
+
+charts:
+- name: jaeger-operator
+  override:
+    spec.storage.options.es:
+      server-urls: https://eck-elasticsearch-es-http:9200
+      username: elastic
+      password: tacoword


### PR DESCRIPTION
* istio, jaeger, kiali를 설치하는 service-mesh application 을 정의
* 기존 LMA에 istio, jaeger를 monitoring할 수 있도록 prometheus, grafana, elasticsearch 연동