### PR TITLE
fix: failed to install istio-operator

### DIFF
--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -11,7 +11,7 @@ spec:
     name: istio-operator
     version: 1.7.0
   releaseName: istio-operator
-  targetNamespace: istio-system
+  targetNamespace: istio-operator
   values:
     operatorNamespace: istio-system
     watchedNamespace: istio-system  # namespace list seperated with comma


### PR DESCRIPTION
* istio-system namespace를 helm-operator가 만들어주는데, 이때문에 istio-operator에서 istio-system namespace를 또 만들려고 해서 에러가 발생함.
* helm release의 namespace만 istio-operator namespace로 바꿈.