### PR TITLE
fix: override fullname of prometheus-operator

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -13,6 +13,7 @@ spec:
   releaseName: prometheus-operator
   targetNamespace: lma
   values:
+    fullnameOverride: prometheus-operator
     defaultRules:
       create: false
     global:


### PR DESCRIPTION
* kube-prometheus-stackd으로 차트가 바뀌면서 prometheus-operator 서비스 명이 proemtheus-operator-kube-p-operator로 변경됨..
* 이를 수정하기 위해 fullnameOverride 변수를 prometheus-operator로 변경