### PR TITLE
Use Thanos for Fed-Grafana Datasource

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -935,7 +935,7 @@ spec:
       enabled: true
       sidecar:
         datasources:
-          prometheusAddress: "fed-master-prometheus:9090"
+          prometheusAddress: "thanos-query-frontend:9090"
       istio:
         enabled: true
       jaeger:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -135,7 +135,7 @@ charts:
     metricbeat.elasticsearch.host: https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200
     metricbeat.kibana.host: eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
     metricbeat.prometheus.hosts:
-    - fed-master-prometheus.fed.svc.$(clusterName):9090
+    - thanos-query-frontend.fed.svc.$(clusterName):9090
     tacoWatcher.host: taco-watcher.fed.svc.$(clusterName)
     tacoWatcher.joinCluster.body.kibanaUrl: http://eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
     tacoWatcher.joinCluster.body.grafanaUrl: http://grafana.fed.svc.$(clusterName)


### PR DESCRIPTION
Federation Grafana에서 연동하는 데이터 소스를 Fed-prometheus가 아닌 Thanos로 변경하는 내용입니다.