### PR TITLE
use service-mesh-resource 0.1.8

### DIFF
--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -130,7 +130,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: service-mesh-resource
-    version: 0.1.7
+    version: 0.1.8
   releaseName: service-mesh-controlplane
   targetNamespace: istio-system
   values:
@@ -154,7 +154,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: service-mesh-resource
-    version: 0.1.7
+    version: 0.1.8
   releaseName: service-mesh-gateways
   targetNamespace: istio-system
   values:

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -147,15 +147,15 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: service-mesh-gateways
-  name: service-mesh-gateways
+    name: service-mesh-gateway
+  name: service-mesh-gateway
 spec:
   helmVersion: v3
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: service-mesh-resource
     version: 0.1.8
-  releaseName: service-mesh-gateways
+  releaseName: service-mesh-gateway
   targetNamespace: istio-system
   values:
     IstioOperator:


### PR DESCRIPTION
* 0.1.7 차트는 hanu-helm-repo에 없습니다. 최신 버전인 0.1.8을 사용하도록 변경하였습니다.