### PR TITLE
update kube-prometheus-stack to 14.5.0

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
-    version: 13.7.2
+    version: 14.5.0
   releaseName: prometheus-operator
   targetNamespace: lma
   values:
@@ -66,7 +66,7 @@ spec:
   chart:
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
-    version: 13.7.2
+    version: 14.5.0
   releaseName: prometheus
   targetNamespace: lma
   values:
@@ -168,6 +168,7 @@ spec:
         targetPort: "grpc"
         nodePort: 30901
         type: NodePort
+        clusterIP: ""
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -181,7 +182,7 @@ spec:
   chart:
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
-    version: 13.7.2
+    version: 14.5.0
   releaseName: prometheus-fed-master
   targetNamespace: fed
   values:

--- a/lma/image/image-values.yaml
+++ b/lma/image/image-values.yaml
@@ -91,9 +91,9 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
-    prometheusOperator.image.tag: v0.45.0
+    prometheusOperator.image.tag: v0.46.0
     prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.45.0
+    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 
@@ -109,9 +109,9 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
-    prometheusOperator.image.tag: v0.45.0
+    prometheusOperator.image.tag: v0.46.0
     prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.45.0
+    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 
@@ -127,9 +127,9 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.repository: $(registry)/kube-webhook-certgen
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
-    prometheusOperator.image.tag: v0.45.0
+    prometheusOperator.image.tag: v0.46.0
     prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.45.0
+    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 


### PR DESCRIPTION
* thanosService의 NodePort 지원안되던 이슈 고친 차트로 적용