### PR TITLE
use eck-resource 1.1.0 version

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -461,7 +461,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: eck-resource
-    version: 1.0.1
+    version: 1.1.0
   releaseName: eck-resource
   targetNamespace: lma
   values:
@@ -474,6 +474,11 @@ spec:
         service:
           spec:
             type: NodePort
+            ports:
+            - name: http
+              nodePort: 30002
+              targetPort: 9200
+              port: 9200
       nodeSets:
         master:
           enabled: true


### PR DESCRIPTION
* eck-resource 1.1.0버전을 사용하도록 수정
* 이전 버전에서 elasticsearch CRD의 http 설정이 잘못 들어가있었음
