### PR TITLE
fixes for argocd

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -339,6 +339,9 @@ spec:
     replicaCount: 1
     config:
       containerRegistry: docker.elastic.co
+    internal:
+      manifestGen: true
+      kubeVersion: 1.18.8
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -10,8 +10,8 @@ spec:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: istio-operator
     version: 1.7.0
-  releaseName: istio-operator
-  targetNamespace: istio-operator
+  releaseName: istio-system
+  targetNamespace: istio-system
   values:
     operatorNamespace: istio-system
     watchedNamespace: istio-system  # namespace list seperated with comma


### PR DESCRIPTION
* eck-operator를 만들 때 elastic-system namespace도 같이 만들도록 수정. (argo cd에서 namespace를 만들어 주지 않는다.)
* istio-operator의 namespace는 istio-system으로 수정. (istio-operator namespace를 만들지 않기 때문에 namespace already exists. 문제가 자동 해결됨)