### PR TITLE
Fix some bugs

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -871,7 +871,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.3.0
+    version: 1.4.0
   releaseName: addons
   targetNamespace: lma
   values:
@@ -928,10 +928,11 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.3.0
+    version: 1.4.0
   releaseName: fed-addons
   targetNamespace: fed
   values:
+    createNamespace: true
     metricbeat:
       enabled: true
       elasticsearch:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -479,7 +479,7 @@ spec:
             type: NodePort
             ports:
             - name: http
-              nodePort: 30002
+              nodePort: 30011
               targetPort: 9200
               port: 9200
       nodeSets:

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -119,7 +119,7 @@ spec:
           prometheus: lma
         auth:
           strategy: anonymous #openid, token, openshift, header, anonymous
-        istio_namespace: istio-namespace1
+        istio_namespace: istio-system
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease


### PR DESCRIPTION
* Elasticsearch NodePort 30002는 thanos minio의 nodePort와 겹친다. 그래서 30011번으로 수정
* lma-addons차트 1.4.0에서 namespace를 만들 수 있게 되었다. fed namespace를 만들게 한다. (argoCD로 설치시 fed namespace가 생성되지 않아서 문제 발생)
* kiali-operator의 istio-namespace 값은 실제 존재하는 namespace여야한다. 따라서 istio-system으로 변경한다.