### PR TITLE
Use lma-addons 1.5.0 version

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -871,7 +871,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.4.0
+    version: 1.5.0
   releaseName: addons
   targetNamespace: lma
   values:
@@ -928,7 +928,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/hanu-helm-repo
     name: lma-addons
-    version: 1.4.0
+    version: 1.5.0
   releaseName: fed-addons
   targetNamespace: fed
   values:
@@ -952,6 +952,10 @@ spec:
       istio:
         enabled: true
       jaeger:
+        enabled: true
+      tacoCustomDashboard:
+        enabled: true
+      ceph:
         enabled: true
     serviceMonitor:
       calico:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -948,7 +948,7 @@ spec:
       enabled: true
       sidecar:
         datasources:
-          prometheusAddress: "thanos-query-frontend:9090"
+          prometheusAddress: "fed-master-prometheus:9090"
       istio:
         enabled: true
       jaeger:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -222,7 +222,7 @@ charts:
     minio.persistence.storageClass: $(storageClassName)
     minio.persistence.accessMode: ReadWriteOnce
     minio.persistence.size: 8Gi
-    query.sidecarsService: thanos-sidecars
+    query.dnsDiscovery.sidecarsService: thanos-sidecars
 
 - name: thanos-config
   override:


### PR DESCRIPTION
* lma-addons 1.5.0 version 사용
* grafana dashboard가 fed-master-prometheus를 사용하도록 변경.