### PR TITLE
update service-mesh configs

### DIFF
--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -13,8 +13,8 @@ spec:
   releaseName: istio-operator
   targetNamespace: istio-system
   values:
-    operatorNamespace: istio-system
-    watchedNamespace: istio-system  # namespace list seperated with comma
+    operatorNamespace: istio-operator
+    watchedNamespaces: istio-system,istio-gateway  # namespace list seperated with comma
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -132,7 +132,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/helm-repo
     name: service-mesh-resource
-    version: 0.1.9
+    version: 0.2.1
   releaseName: service-mesh-controlplane
   targetNamespace: istio-system
   values:
@@ -156,7 +156,7 @@ spec:
   chart:
     repository: https://openinfradev.github.io/helm-repo
     name: service-mesh-resource
-    version: 0.1.9
+    version: 0.2.1
   releaseName: service-mesh-gateway
   targetNamespace: istio-system
   values:

--- a/service-mesh/base/site-values.yaml
+++ b/service-mesh/base/site-values.yaml
@@ -21,7 +21,7 @@ charts:
 - name: service-mesh-gateway
   override:
     IstioOperator.ingressGateways:
-      - name: istio-ingressgateway
+      - name: default
         resources:
           requests_cpu: 1000m
           requests_memory: 1024Mi
@@ -29,4 +29,5 @@ charts:
           limits_memory: 2048Mi
         hpaMaxReplicas: 10
         hpaTargetCpuUtilization: 80
+        serviceType: NodePort
     IstioOperator.egressGateways: []


### PR DESCRIPTION
along with https://github.com/openinfradev/helm-charts/pull/37

* istio-operator controller 자체는 별도의 namespace에 뜨도록 함.
* default gateway 명칭 변경