### PR TITLE
eck-operator search the port name "https"

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -481,7 +481,7 @@ spec:
           spec:
             type: NodePort
             ports:
-            - name: http
+            - name: https
               nodePort: 30011
               targetPort: 9200
               port: 9200


### PR DESCRIPTION
kibana에서 elasticsearch를 연결할때 https라는 포트를 찾고 있는데 해당 서비스의 포트에는 http만 존재하여 찾지못함
http라고 명명된 포트는 실제로 https (tls) 통신을 하고 있으므로 명칭을 바꿔주는 것은 문제 없어 보임
따라서 본 PR을 통해 해결하고자 함