### PR TITLE
Default port 30007 for prometheus sidecar in TACO LMA

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1268,6 +1268,8 @@ spec:
       secret_key: TO_BE_FIXED
     sidecarsService:
       enabled: true
+      type: NodePort
+      nodePort: 30007
       name: TO_BE_FIXED
       port: 30901
       endpoints: [] # TO_BE_FIXED


### PR DESCRIPTION
30007 포트를 prometheus sidecar의 default 노드포트로...