### PR TITLE
bugfix: thanos-sidecars handle raw data within 3h

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -158,7 +158,7 @@ spec:
           objectStorageConfig:
             key: objstore.yml 
             name: TO_BE_FIXED # secret name
-          minTime: 2h
+          minTime: -3h
       service:
         nodePort: 30008
         type: NodePort
@@ -1267,7 +1267,7 @@ spec:
       access_key: TO_BE_FIXED
       secret_key: TO_BE_FIXED
     sidecarsService:
-      enabled: true
+      enabled: false
       type: NodePort
       nodePort: 30007
       name: TO_BE_FIXED

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -197,13 +197,16 @@ charts:
     clusterDomain: $(clusterName)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
+    query.dnsDiscovery.sidecarsService: lma-thanos-discovery
+    # query.stores:
+    #   - lma-thanos-discovery.lma.svc.$(clusterName)
     queryFrontend.nodeSelector: $(nodeSelector)
     queryFrontend.service.type: NodePort
     queryFrontend.service.http.nodePort: 30007
     bucketweb.nodeSelector: $(nodeSelector)
     compactor.nodeSelector: $(nodeSelector)
     storegateway.nodeSelector: $(nodeSelector)
-    ruler.nodeSelector: $(nodeSelector)      
+    ruler.nodeSelector: $(nodeSelector)
 
     queryFrontend.config: |-
         type: IN-MEMORY
@@ -249,7 +252,6 @@ charts:
     minio.persistence.storageClass: $(storageClassName)
     minio.persistence.accessMode: ReadWriteOnce
     minio.persistence.size: 8Gi
-    query.dnsDiscovery.sidecarsService: thanos-sidecars
 
 - name: thanos-config
   override:


### PR DESCRIPTION
1. thanos 질의가 수행되지 못하게 되었던 버그 수정
2. prometheus내부의 thanos-sidecar에 대한 중복생성 이슈해소
