### PR TITLE
TACODEV-858: support a github directory as the location of helm charts

### DIFF
--- a/admin-tools/base/resources.yaml
+++ b/admin-tools/base/resources.yaml
@@ -7,6 +7,7 @@ metadata:
   name: keycloak
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: keycloak
     version: 8.2.2
@@ -54,6 +55,7 @@ metadata:
   name: cloud-console
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: cloud-console
     version: 1.0.7
@@ -119,6 +121,7 @@ metadata:
   name: custom-network
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: custom-network
     version: 1.0.10
@@ -141,6 +144,7 @@ metadata:
   name: taco-registry
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: taco-registry
     version: 1.0.6
@@ -279,6 +283,7 @@ metadata:
   name: site-mirror-registry
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: site-mirror-registry
     version: 0.0.3
@@ -311,6 +316,7 @@ metadata:
   name: cronjob-backup-cloudconsole
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: cronjob-backup-cloudconsole
     version: 1.0.0
@@ -337,6 +343,7 @@ metadata:
   name: cronjob-backup-keycloak
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: cronjob-backup-keycloak
     version: 1.0.2

--- a/cloud-console/base/resources.yaml
+++ b/cloud-console/base/resources.yaml
@@ -7,6 +7,7 @@ metadata:
   name: keycloak
 spec:
   chart:
+    type: helmrepo
     repository: https://codecentric.github.io/helm-charts
     name: keycloak
     version: 8.2.2
@@ -55,6 +56,7 @@ metadata:
   name: cloud-console
 spec:
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: cloud-console
     version: 1.0.0

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
     version: 14.5.0
@@ -64,6 +65,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
     version: 14.5.0
@@ -183,6 +185,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
     version: 14.5.0
@@ -329,6 +332,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://helm.elastic.co
     name: eck-operator
     version: 1.6.0
@@ -356,6 +360,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     # repository: https://kubernetes.github.io/kube-state-metrics
     # --------------------------------------------------------------------
     # this repo is not working on 2021.1.6
@@ -383,6 +388,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: prometheus-node-exporter
     version: 1.11.2
@@ -402,6 +408,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: prometheus-pushgateway
     version: 1.5.1
@@ -423,6 +430,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: prometheus-process-exporter
     version: 0.1.0
@@ -465,6 +473,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: eck-resource
     version: 1.1.0
@@ -555,6 +564,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://grafana.github.io/helm-charts
     name: grafana
     version: 5.5.7
@@ -596,6 +606,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: fluentbit-operator
     version: 1.0.10
@@ -639,6 +650,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: fluentbit-operator
     version: 1.0.10
@@ -872,6 +884,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: lma-addons
     version: 1.5.0
@@ -963,6 +976,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: prometheus-adapter
     version: 2.5.1
@@ -986,6 +1000,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: kubernetes-event-exporter
     version: 1.0.0
@@ -1013,6 +1028,7 @@ metadata:
 spec:
   helmVersion: v3 
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: taco-watcher
     version: 0.1.0
@@ -1048,6 +1064,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://charts.bitnami.com/bitnami
     name: thanos
     version: 3.4.0
@@ -1203,6 +1220,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: thanos-config
     version: 0.1.3

--- a/openstack/base/resources.yaml
+++ b/openstack/base/resources.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: glance
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -94,6 +95,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: heat
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -158,6 +160,7 @@ spec:
   helmVersion: v3
   timeout: 30000
   chart:
+    type: helmrepo
     name: horizon
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -253,6 +256,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: ingress
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -293,6 +297,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: keystone
     version: 0.1.0
@@ -347,6 +352,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: libvirt
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -388,6 +394,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: mariadb
     repository: TO_BE_FIXED
     version: 0.1.1
@@ -428,6 +435,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: memcached
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -454,6 +462,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: neutron
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -618,6 +627,7 @@ spec:
   helmVersion: v3
   timeout: 30000
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: nova
     version: 0.1.0
@@ -765,6 +775,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: prometheus-openstack-exporter
     version: 0.1.0
@@ -807,6 +818,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     name: rabbitmq
     repository: TO_BE_FIXED
     version: 0.1.0
@@ -843,6 +855,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: ceph-provisioners
     version: 0.1.0
@@ -889,6 +902,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: cinder
     version: 0.1.1
@@ -990,6 +1004,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: ironic
     version: 0.1.0
@@ -1109,6 +1124,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: sona
     version: 0.1.0
@@ -1154,6 +1170,7 @@ metadata:
   name: openvswitch
 spec:
   chart:
+    type: helmrepo
     repository: TO_BE_FIXED
     name: openvswitch
     version: 0.1.0

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: istio-operator
     version: 1.7.0
@@ -26,6 +27,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     #repository: https://jaegertracing.github.io/helm-charts
     repository: https://openinfradev.github.io/helm-repo
     name: jaeger-operator
@@ -86,6 +88,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://kiali.org/helm-charts
     name: kiali-operator
     version: 1.30.0
@@ -131,6 +134,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: service-mesh-resource
     version: 0.2.1
@@ -156,6 +160,7 @@ metadata:
 spec:
   helmVersion: v3
   chart:
+    type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: service-mesh-resource
     version: 0.2.1


### PR DESCRIPTION
내용
현재 사용하는 manifest는 helm repo에 저장된 chart를 기반으로 돌아가도록 되어있다.
개발의 편의성을 위해 github이나 local에 올라간 소스를 기반으로 배포하는 것을 위한 유틸리티가 있다면 좋겠다.

수행내역
spec.chart를 재정의해서 필요한 기능을 수행할수 있도록 제반 유틸리티 수정

    type: helmrepo
    repository: https://prometheus-community.github.io/helm-charts
    name: kube-prometheus-stack
    version: 14.5.0
 또는

    type: git
    repository: git@github.com:helm/charts
    name: charts/stable/prometheus-operator
    version: master 
와 같이 정의 가능하고 type은 생략할 수 있고 기본값 helmrepo로 산정되어 작업됨

type이 git이면 repository는 git 과 같은 의미 name은 path와 같은 의미 version은 ref와 같은 의미로 동작하도록 한다.

산출물
https://github.com/openinfradev/decapod-site/pull/33
https://github.com/openinfradev/decapod-base-yaml/pull/87
https://github.com/openinfradev/kustomize-helm-transformer/pull/30