### PR TITLE
TACODEV-774: add service monitors and dashboards for metrics from arg…

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -904,7 +904,11 @@ spec:
       tacoCustomDashboard:
         enabled: true
       ceph:
-        enabled: true
+        enabled: false
+      argocd:
+        enabled: false
+      argowf:
+        enabled: false
     serviceMonitor:
       calico:
         enabled: true
@@ -925,6 +929,12 @@ spec:
         interval: TO_BE_FIXED
       grafana:
         enabled: true
+        interval: TO_BE_FIXED
+      argocd:
+        enabled: false
+        interval: TO_BE_FIXED
+      argowf:
+        enabled: false
         interval: TO_BE_FIXED
       ceph:
         enabled: false  #FIXME

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -160,6 +160,8 @@ charts:
     # Initialize the kibana index
     kibanaInit.url: http://eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
     serviceMonitor.grafana.interval: $(serviceScrapeInterval)
+    serviceMonitor.argocd.interval: $(serviceScrapeInterval)
+    serviceMonitor.argowf.interval: $(serviceScrapeInterval)
     serviceMonitor.processExporter.interval: $(serviceScrapeInterval)
     serviceMonitor.ceph.interval: $(serviceScrapeInterval)
     serviceMonitor.calico.interval: $(serviceScrapeInterval)


### PR DESCRIPTION
…o-series

**내용**
Argo worflow/CD도 prometheus metric으로 수집할 수 있다. Argo worklfow/CD의 metric을 조사하고, Argo CD 의 주요 metric 수집한다.
argo cd/workflow exporter 존재함, 서비스 모니터 생성해서 prometheus로 데이터 저장 확인 (lma-addons) 
grafana dashboard 까지 추가, 확인 (grafana labs에 있는 대시보드 활용) 

**이 PR은**
argo에 대한 메트릭관련 dashboard와 service monitor 설치여부지원