### PR TITLE
creates namespace for eck-operator

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -346,7 +346,7 @@ spec:
     internal:
       manifestGen: true
       kubeVersion: 1.18.8
-      createOperatorNamespace: false
+      createOperatorNamespace: true
     softMultiTenancy:
       enabled: false
   wait: true


### PR DESCRIPTION
* eck-operator가 설치될 namespace를 만들어줘야함. (decapod v2에서는 namespace생성이 필요하기때문에)
* eck-operator helm chart의 createOperatorNamespace 변수로 namespace 생성 가능