### PR TITLE
Add prepare-etcd-secret

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1153,3 +1153,33 @@ spec:
       port: 30901
       endpoints: [] # TO_BE_FIXED
   wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: prepare-etcd-secret
+  name: prepare-etcd-secret
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://openinfradev.github.io/helm-repo
+    name: prepare-etcd-secret
+    version: 0.1.1
+  releaseName: prepare-etcd-secret
+  targetNamespace: lma
+  values:
+    etcd:
+      certdir: /etc/kubernetes/pki/etcd
+      certfile: ca.crt
+      client_certfile: peer.crt
+      client_keyfile: peer.key
+    # master node의 label을 환경에 맞게 적어야함
+    # ex) "node-role.kubernetes.io/master": "" 
+    nodeSelector: {} # TO_BE_FIXED
+    # master node에 taint가 있는 경우 필요
+    # ex) - key: "node-role.kubernetes.io/master"
+    #       effect: "NoSchedule"
+    #       operator: "Exists"
+    tolerations: [] # TO_BE_FIXED

--- a/lma/image/image-values.yaml
+++ b/lma/image/image-values.yaml
@@ -175,3 +175,8 @@ charts:
 
 - name: thanos-config
   override: {}
+
+- name: prepare-etcd-secret
+  override:
+    image.repository: $(registry)/hyperkube
+    image.tag: v1.18.8


### PR DESCRIPTION
LMA 서비스에 필요한 master node에서 etcd secret을 생성하는 prepare-etcd-secret 차트의 대한 base yaml입니다.
