### PR TITLE
override argo image tag

### DIFF
--- a/decapod-controller/base/resources.yaml
+++ b/decapod-controller/base/resources.yaml
@@ -93,8 +93,12 @@ spec:
   values:
     server:
       serviceType: NodePort
+      image:
+        tag: v3.1.0
     controller:
       containerRuntimeExecutor: k8sapi
+      image:
+        tag: v3.1.0
       persistence:
         nodeStatusOffLoad: true
         archive: true


### PR DESCRIPTION
expression tag template이라는 new feature를 사용하기 위해 argo workflows v3.1.0 을 사용해야 함.