### PR TITLE
Update for kube 1.22

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -10,7 +10,7 @@ spec:
     type: helmrepo
     repository: https://prometheus-community.github.io/helm-charts
     name: kube-prometheus-stack
-    version: 14.5.0
+    version: 21.0.3
   releaseName: prometheus-operator
   targetNamespace: lma
   values:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -253,7 +253,7 @@ spec:
     type: helmrepo
     repository: https://helm.elastic.co
     name: eck-operator
-    version: 1.6.0
+    version: 1.8.0
   releaseName: eck-operator
   targetNamespace: elastic-system
   values:
@@ -261,9 +261,9 @@ spec:
     replicaCount: 1
     config:
       containerRegistry: docker.elastic.co
-    internal:
+    global:
       manifestGen: true
-      kubeVersion: 1.18.8
+      kubeVersion: 1.22.2
       createOperatorNamespace: true
     softMultiTenancy:
       enabled: false
@@ -399,7 +399,8 @@ spec:
   targetNamespace: lma
   values:
     elasticsearch:
-      version: 7.5.1
+      image:
+        tag: 7.15.2
       adminPassword: TO_BE_FIXED
       enabled: true 
       count: 3        # FIXME
@@ -454,7 +455,8 @@ spec:
             storageClassName: TO_BE_FIXED
             size: 0.5Gi
     kibana:
-      version: 7.5.1
+      image:
+        tag: 7.15.2
       enabled: true
       http:
         tls:

--- a/lma/image/image-values.yaml
+++ b/lma/image/image-values.yaml
@@ -88,8 +88,8 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
     prometheusOperator.image.tag: v0.46.0
-    prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
+    prometheusOperator.prometheusConfigReloader.image.repository: $(registry)/prometheus-operator/prometheus-config-reloader
+    prometheusOperator.prometheusConfigReloader.image.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 
@@ -106,8 +106,8 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
     prometheusOperator.image.tag: v0.46.0
-    prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
+    prometheusOperator.prometheusConfigReloader.image.repository: $(registry)/prometheus-operator/prometheus-config-reloader
+    prometheusOperator.prometheusConfigReloader.image.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 
@@ -124,8 +124,8 @@ charts:
     prometheusOperator.admissionWebhooks.patch.image.tag: v1.5.0
     prometheusOperator.image.repository: $(registry)/prometheus-operator/prometheus-operator
     prometheusOperator.image.tag: v0.46.0
-    prometheusOperator.prometheusConfigReloaderImage.repository: $(registry)/prometheus-operator/prometheus-config-reloader
-    prometheusOperator.prometheusConfigReloaderImage.tag: v0.46.0
+    prometheusOperator.prometheusConfigReloader.image.repository: $(registry)/prometheus-operator/prometheus-config-reloader
+    prometheusOperator.prometheusConfigReloader.image.tag: v0.46.0
     prometheus.prometheusSpec.image.repository: $(registry)/prometheus/prometheus
     prometheus.prometheusSpec.image.tag: v2.24.0
 

--- a/lma/image/image-values.yaml
+++ b/lma/image/image-values.yaml
@@ -9,9 +9,9 @@ charts:
 - name: eck-resource
   override:
     elasticsearch.image.repository: $(registry)/elasticsearch/elasticsearch
-    elasticsearch.image.tag: 7.5.1
+    elasticsearch.image.tag: 7.15.2
     kibana.image.repository: $(registry)/kibana/kibana
-    kibana.image.tag: 7.5.1
+    kibana.image.tag: 7.15.2
 
 - name: eck-operator
   override:


### PR DESCRIPTION
API 변경 사항에 대응하기 위해 아래 차트들에 대한 업그레이드를 수행하였습니다.

prometheus-operator: 14.5.0 -> 21.0.3
eck-operator: 1.6.0 -> 1.8.0
eck-resource: elastisearch 버전 변경 (7.5.1 -> 7.15.2)