### PR TITLE
override loki address to fit latest promtail chart

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1200,7 +1200,7 @@ spec:
   values:
     image:
       tag: 2.4.1
+    config:
+      lokiAddress: http://loki.lma:3100/loki/api/v1/push
     serviceMonitor:
-      enabled: false
-    syslogService:
       enabled: false

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -252,5 +252,6 @@ charts:
 
 - name: promtail
   override:
+    config.lokiAddress: http://loki.lma:3100/loki/api/v1/push
     serviceMonitor.enabled: false
     syslogService.enabled: false


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/43

Promtail 차트의 (거의) 최신 버전인 3.9.1 차트를 살펴보니, scrapeConfig 설정 부분에 nodeName label이 추가되어서, 별도로 이 부분을 override할 필요가 없어졌습니다.  단, 차트의 value structure가 살짝 바뀌어 loki server address를 적절한 값으로 override해주어야 하기에 해당 내용 추가하였습니다.