### PR TITLE
Loki로 syslog 수집

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1199,6 +1199,8 @@ spec:
   values:
     image:
       tag: 2.4.1
+    extraArgs:
+      - "-config.expand-env=true"
     config:
       lokiAddress: http://loki.lma:3100/loki/api/v1/push
       snippets:
@@ -1209,6 +1211,7 @@ spec:
                 - localhost
               labels:
                 job: systemlog
+                host: ${HOSTNAME}
                 __path__: /var/log/messages
     serviceMonitor:
       enabled: false

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1201,5 +1201,28 @@ spec:
       tag: 2.4.1
     config:
       lokiAddress: http://loki.lma:3100/loki/api/v1/push
+      snippets:
+        extraScrapeConfigs: |
+          - job_name: systemlog
+            static_configs:
+            - targets:
+                - localhost
+              labels:
+                job: systemlog
+                __path__: /var/log/messages
     serviceMonitor:
       enabled: false
+    defaultVolumes:
+      - name: containers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: varlog
+        hostPath:
+          path: /var/log
+    defaultVolumeMounts:
+      - name: containers
+        mountPath: /var/lib/docker/containers
+        readOnly: true
+      - name: varlog
+        mountPath: /var/log
+        readOnly: true


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/106

* as-is: default로 /var/log/pods/ 아래의 로그 파일만 수집
* to-be: /var/log/messages 파일까지 수집하기 위해, 차트의 volume 및 volumeMount 값을 override하여 /var/log 전체를 마운트하도록 변경

추가로, hostname 값을 label로 추가하기 위해, cmd line argument 추가하였습니다.