### PR TITLE
lma: grafana: remove devopsprodigy-kubegraf-app plugin

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -510,11 +510,9 @@ spec:
       plugins:
         vonage-status-panel: true
         grafana-piechart-panel: true
-        devopsprodigy-kubegraf-app: true
     plugins:
     - vonage-status-panel
     - grafana-piechart-panel
-    - devopsprodigy-kubegraf-app
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1


### PR DESCRIPTION
devopsprodigy-kubegraf-app 플러그인이 Grafana v8 에서 동작하지 않기 때문에 제거합니다.
- https://github.com/devopsprodigy/kubegraf/issues/62

Grafana 8에서 동작하는 구현이 v2라는 이름으로 개발 중 (https://github.com/devopsprodigy/kubegraf-v2) 이긴 한데 정식 릴리즈는 되지 않았고 직접 플러그인을 빌드해야 합니다.
- https://github.com/devopsprodigy/kubegraf-v2/issues/1#issuecomment-989800770
- https://github.com/devopsprodigy/kubegraf/issues/68#issuecomment-939680310