### PR TITLE
Loki 로 k8s event 수집

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,7 +29,6 @@ jobs:
           .github/workflows/render.sh lma
           .github/workflows/render.sh openstack
           .github/workflows/render.sh cloud-console
-          .github/workflows/render.sh tks-cluster aws
 
       - name: install helm
         run: |

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1204,6 +1204,16 @@ spec:
     config:
       lokiAddress: http://loki.lma:3100/loki/api/v1/push
       snippets:
+        pipelineStages:
+        - cri: {}
+        - match:
+            selector: '{app="eventrouter"}'
+            stages:
+            - json:
+                expressions:
+                  namespace: event.metadata.namespace
+            - labels:
+                namespace: ""
         extraScrapeConfigs: |
           - job_name: systemlog
             static_configs:
@@ -1229,3 +1239,24 @@ spec:
       - name: varlog
         mountPath: /var/log
         readOnly: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: eventrouter
+  name: eventrouter
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://helm-charts.wikimedia.org/stable/
+    name: eventrouter
+    version: 0.4.0
+  releaseName: eventrouter
+  targetNamespace: lma
+  values:
+    image:
+      # Use image built from openshift eventrouter src
+      repository: sktdev/os-eventrouter
+      tag: 69a58b


### PR DESCRIPTION
https://github.com/openinfradev/decapod-base-yaml/pull/135 에서 작업했던 내용 다시 올립니다 (기존 PR 의 코드 내용이 바뀌었으니 그부분 말고 대화 부분만 참고하세요)

wikimedia chart 는 그대로 사용하고, openshift  측 repo (https://github.com/openshift/eventrouter) 의 Dockerfile 로 이미지 빌드하여 "sktdev" repo에 올리고, 해당 이미지 사용하도록 base-yaml에서 override하였습니다. (관련 history는 위의 기존 PR 에 적혀있습니다)

openshift 에서 코드를 많이 수정한 게 아니라서 이 조합도 정상적으로 잘 동작하는 것으로 보입니다.  Openshift의 코드 업데이트가 현재는 거의 멈춰있는데, 만약 다시 변경이 활발히 일어난다면 SKT 자체적으로 주기적인 이미지 빌드 파이프라인 구축도 고려해보려 합니다.


