### PR TITLE
upgrade grafana chart to 6.19.4

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -486,7 +486,7 @@ spec:
     type: helmrepo
     repository: https://grafana.github.io/helm-charts
     name: grafana
-    version: 6.17.4
+    version: 6.19.4
   releaseName: grafana
   targetNamespace: lma
   values:
@@ -745,7 +745,7 @@ spec:
       namespace: lma
       prometheus:
         enabled: true
-        url: "thanos-query:9090"
+        url: "thanos-query.lma:9090"
       loki:
         enabled: true
         url: "loki.lma:3100"


### PR DESCRIPTION
차트 버전 6.17.4 에서 사용하는 이미지의 경우 계속 crash 되는 증상이 있어 버전 업그레이드합니다.