### PR TITLE
update prepare-etcd-secret version

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1103,7 +1103,7 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: prepare-etcd-secret
-    version: 0.1.1
+    version: 0.2.0
   releaseName: prepare-etcd-secret
   targetNamespace: lma
   values:


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/92 반영 내용을 사용하기 위해 차트 버전을 업데이트하였습니다.