### PR TITLE
upgrade istio: v1.11.7, jaeger: 1.24.0,  kiali: v1.38.1

### DIFF
--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -32,8 +32,6 @@ spec:
   releaseName: istio-operator
   targetNamespace: istio-system
   values:
-    hub: docker.io/istio
-    tag: 1.10.2
     operatorNamespace: istio-operator
     watchedNamespaces: istio-system,istio-gateway  # namespace list seperated with comma
   wait: true
@@ -57,13 +55,10 @@ spec:
   values:
     createNamespace: false
     IstioOperator:
-      image:
-        hub: docker.io/istio
-        tag: 1.10.2
       enableControlplane: true
       enableGateway: false
       profile: default 
-      revision: "1-9-1"
+      revision: "1-11-7"
       meshConfig:
         enableAccessLog: true
         enableTracing: true
@@ -74,7 +69,7 @@ spec:
             service: jaeger-operator-jaeger-collector.istio-system
             port: 14250
         defaultConfig:
-          discoveryAddress: istiod-1-9-1.istio-system.svc:15012
+          discoveryAddress: istiod-1-11-7.istio-system.svc:15012
           tracing:
             zipkin:
               address: jaeger-operator-jaeger-collector.istio-system:9411
@@ -122,7 +117,7 @@ spec:
     IstioOperator:
       enableControlplane: false
       enableGateway: true
-      revision: "1-9-1"
+      revision: "1-11-7"
       profile: empty
       values:
         global:
@@ -185,7 +180,7 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: jaeger-operator
-    version: 2.20.0
+    version: 2.23.0
   releaseName: jaeger-operator-crds
   targetNamespace: istio-system
   values: {}
@@ -201,7 +196,7 @@ spec:
   chart:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
-    version: 2.20.0
+    version: 2.23.0
     name: jaeger-operator
   releaseName: jaeger-operator
   targetNamespace: istio-system
@@ -286,7 +281,7 @@ spec:
     type: helmrepo
     repository: https://kiali.org/helm-charts
     name: kiali-operator
-    version: 1.34.0
+    version: 1.38.1
   releaseName: kiali-operator-crds
   targetNamespace: istio-system
   values: {}
@@ -303,7 +298,7 @@ spec:
     type: helmrepo
     repository: https://kiali.org/helm-charts
     name: kiali-operator
-    version: 1.34.0
+    version: 1.38.1
   releaseName: kiali-operator
   targetNamespace: istio-system
   values:
@@ -355,7 +350,7 @@ spec:
       customDashboards:
         enabled: true
       istio:
-        configMapName: istio-1-9-1
+        configMapName: istio-1-11-7
         istioIdentityDomain: "svc.cluster.local"
       prometheus:
         url: http://prometheus-kube-prometheus-prometheus.prometheus.svc:9090

--- a/service-mesh/base/site-values.yaml
+++ b/service-mesh/base/site-values.yaml
@@ -20,9 +20,7 @@ global:
 charts:
 - name: istio-operator
   override:
-    revision: "1-10-2"
-    hub: docker.io/istio
-    tag: 1.10.2
+    revision: "1-11-7"
     operator.resources.limits.cpu: 200m
     operator.resources.limits.memory: 256Mi
     operator.resources.requests.cpu: 50m
@@ -30,14 +28,12 @@ charts:
 
 - name: servicemesh-controlplane
   override:
-    IstioOperator.revision: "1-10-2"
-    IstioOperator.image.hub: docker.io/istio
-    IstioOperator.image.tag: 1.10.2
+    IstioOperator.revision: "1-11-7"
     IstioOperator.meshConfig.enableTracing: true
     IstioOperator.meshConfig.tracingSampling: 100
     IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.service: jaeger-operator-jaeger-collector.istio-system.svc
     IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.port: 14250
-    IstioOperator.meshConfig.defaultConfig.discoveryAddress: istiod-1-10-2.istio-system.svc:15012
+    IstioOperator.meshConfig.defaultConfig.discoveryAddress: istiod-1-11-7.istio-system.svc:15012
     IstioOperator.meshConfig.defaultConfig.tracing.zipkin.address: jaeger-operator-jaeger-collector.istio-system.svc:9411
     IstioOperator.meshConfig.defaultConfig.tracing.sampling: 100
     IstioOperator.values.global.istioNamespace: istio-system
@@ -48,9 +44,7 @@ charts:
 
 - name: servicemesh-gateway
   override:
-    IstioOperator.revision: "1-10-2"
-    IstioOperator.image.hub: docker.io/istio
-    IstioOperator.image.tag: 1.10.2
+    IstioOperator.revision: "1-11-7"
     IstioOperator.values.global.istioNamespace: istio-system
     IstioOperator.components.ingressGateways.name: istio-ingress-gateway
     IstioOperator.components.ingressGateways.namespace: istio-system
@@ -89,7 +83,7 @@ charts:
       username: elastic
       password: tacoword
     JaegerIngress:
-      enabled: true
+      enabled: false
       namespace: istio-system
       rules:
       - host: jaeger.k2-node01
@@ -116,7 +110,7 @@ charts:
     deployment.resources.limits.cpu: 1000m
     deployment.resources.limits.memory: 2048Mi
     deployment.nodeSelector: $(serviceMeshControlNodeSelector)
-    externalServices.istio.configMapName: istio-1-10-2
+    externalServices.istio.configMapName: istio-1-11-7
     externalServices.istio.istioIdentityDomain: "svc.cluster.local"
     externalServices.prometheus.url: http://lma-prometheus.lma.svc:9090
     externalServices.tracing.inClusterUrl: http://jaeger-operator-jaeger-query.istio-system:16686
@@ -125,7 +119,7 @@ charts:
     externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
     externalServices.grafana.url: http://k1-master01:30009
     KialiIngress:
-      enabled: true
+      enabled: false
       namespace: istio-system
       rules:
       - host: kiali.k2-node01

--- a/service-mesh/image/image-values.yaml
+++ b/service-mesh/image/image-values.yaml
@@ -14,42 +14,42 @@ charts:
 - name: servicemesh-controlplane
   override: 
     IstioOperator.image.hub: $(registry)/istio-testing
-    IstioOperator.image.tag: 1.11-alpha.aa439f6e4772aa52acafa11ac7a5fbdfbb160357
+    IstioOperator.image.tag: 1.14-alpha.82cbd49db92acce69184ab4e9b95e033ea8ab390
 
 - name: servicemesh-gateway
   override:
     IstioOperator.image.hub: $(registry)/istio-testing
-    IstioOperator.image.tag: 1.11-alpha.aa439f6e4772aa52acafa11ac7a5fbdfbb160357
+    IstioOperator.image.tag: 1.14-alpha.82cbd49db92acce69184ab4e9b95e033ea8ab390
 
 - name: jaeger-operator
   override:
     image.repository: $(registry)/jaegertracing/jaeger-operator
-    image.tag: 1.21.2
+    image.tag: 1.24.0
     collectorImage.repository: $(registry)/jaegertracing/jaeger-collector
-    collectorImage.tag: 1.21.0
+    collectorImage.tag: 1.24.0
     agentImage.repository: $(registry)/jaegertracing/jaeger-agent
-    agentImage.tag: 1.21.0
+    agentImage.tag: 1.24.0
     ingesterImage.repository: $(registry)/jaegertracing/jaeger-ingester
-    ingesterImage.tag: 1.21.0
+    ingesterImage.tag: 1.24.0
     queryImage.repository: $(registry)/jaegertracing/jaeger-collector
-    queryImage.tag: 1.21.0
+    queryImage.tag: 1.24.0
 
 - name: servicemesh-jaeger-resource
   override:
     image.repository: $(registry)/jaegertracing/jaeger-operator
-    image.tag: 1.21.2
+    image.tag: 1.24.0
     collectorImage.repository: $(registry)/jaegertracing/jaeger-collector
-    collectorImage.tag: 1.21.0
+    collectorImage.tag: 1.24.0
     agentImage.repository: $(registry)/jaegertracing/jaeger-agent
-    agentImage.tag: 1.21.0
+    agentImage.tag: 1.24.0
     ingesterImage.repository: $(registry)/jaegertracing/jaeger-ingester
-    ingesterImage.tag: 1.21.0
+    ingesterImage.tag: 1.24.0
     queryImage.repository: $(registry)/jaegertracing/jaeger-collector
-    queryImage.tag: 1.21.0
+    queryImage.tag: 1.24.0
 
 - name: kiali-operator
   override:
     image.repo: $(registry)/kiali/kiali-operator
-    image.tag: v1.34.0
+    image.tag: v1.38.1
 
 


### PR DESCRIPTION
- istio operator 는 upstream chart 를 가져와서 openinfradev/helm-repo 에 저장 (app version: 1.11.7, chart version: 1.7)
- jaeger operator 는  upstream chart 를 가져와서 openinfradev/helm-repo 에 저장 (app version: 1.24.0, chart version: 2.23.0)
- kiali operator 는 upstream chart 를 그대로 활용 (chart 버전이 0.0.0 으로 되어 있어서 이전 방법을 그대로 따름) (app version: 1.38.1, chart version: 1.38.1)