### PR TITLE
Upgrade service-mesh version

### DIFF
--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -3,169 +3,118 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: istio-operator-crds
-  name: istio-operator-crds
+    name: istio-base
+  name: istio-base
 spec:
   helmVersion: v3
   chart:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
-    name: istio-operator
-    version: 1.7.0
-  releaseName: istio-operator-crds
+    name: istio-base
+    version: 1.13.1
+  releaseName: istio-base
   targetNamespace: istio-system
   values: {}
----
-apiVersion: helm.fluxcd.io/v1
-kind: HelmRelease
-metadata:
-  labels:
-    name: istio-operator
-  name: istio-operator
-spec:
-  helmVersion: v3
-  chart:
-    type: helmrepo
-    repository: https://openinfradev.github.io/helm-repo
-    name: istio-operator
-    version: 1.7.0
-  releaseName: istio-operator
-  targetNamespace: istio-system
-  values:
-    operatorNamespace: istio-operator
-    watchedNamespaces: istio-system,istio-gateway  # namespace list seperated with comma
-  wait: true
-
----
-apiVersion: helm.fluxcd.io/v1
-kind: HelmRelease
-metadata:
-  labels:
-    name: servicemesh-controlplane
-  name: servicemesh-controlplane
-spec:
-  helmVersion: v3
-  chart:
-    type: helmrepo
-    repository: https://openinfradev.github.io/helm-repo
-    name: servicemesh-istio-resource
-    version: 1.7.0
-  releaseName: servicemesh-controlplane
-  targetNamespace: istio-system
-  values:
-    createNamespace: false
-    IstioOperator:
-      enableControlplane: true
-      enableGateway: false
-      profile: default 
-      revision: "1-11-7"
-      meshConfig:
-        enableAccessLog: true
-        enableTracing: true
-        enablePrometheusMerge: true
-        enableAutoMtls: false
-        extensionProviders:
-          envoyExtAuthzGrpc:
-            service: jaeger-operator-jaeger-collector.istio-system
-            port: 14250
-        defaultConfig:
-          discoveryAddress: istiod-1-11-7.istio-system.svc:15012
-          tracing:
-            zipkin:
-              address: jaeger-operator-jaeger-collector.istio-system:9411
-            sampling: 100.0 # TO_BE_FIXED (0.0 ~ 100.0)
-      values:
-        global:
-          logging:
-            level: "default:info"
-          istioNamespace: istio-system
-      components:
-        pilot:
-          k8s:
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 1024Mi
-            hpaSpec:
-              maxReplicas: 10
-              minReplicas: 2
-            nodeSelector:
-              servicemesh: enabled
-        ingressGateways:
-          enabled: false
-        egressGateways:
-          enabled: false
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: servicemesh-gateway
-  name: servicemesh-gateway
+    name: istiod
+  name: istiod
 spec:
   helmVersion: v3
   chart:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
-    name: servicemesh-istio-resource
-    version: 1.7.0
-  releaseName: servicemesh-gateway
+    name: istiod
+    version: 1.13.1
+  releaseName: istiod
   targetNamespace: istio-system
   values:
-    createNamespace: false
-    IstioOperator:
-      enableControlplane: false
-      enableGateway: true
-      revision: "1-11-7"
-      profile: empty
-      values:
-        global:
-          logging:
-            level: "default:info"
-          istioNamespace: istio-system
-      components:
-        ingressGateways:
-          name: istio-ingress-gateway
-          namespace: istio-system
-          label:
-            gateway: taco-ingress
-          enabled: true
-          k8s:
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 1024Mi
-            hpaSpec:
-              maxReplicas: 10
-              minReplicas: 2
-            nodeSelector:
-              taco-ingress-gateway: enabled
-            service:
-              type: NodePort
-              ports:
-                httpNodePort: 31081
-                httpsNodePort: 31443
-        egressGateways:
-          name: istio-egress-gateway
-          namespace: istio-system
-          label:
-            gateway: taco-egress
-          enabled: false
-          k8s:
-            resources:
-              requests:
-                cpu: 1000m
-                memory: 1024Mi
-              limits:
-                cpu: 4000m
-                memory: 4096Mi
-            hpaSpec:
-              maxReplicas: 10
-              minReplicas: 2
-              targetAverageUtilization: 80
-            nodeSelector:
-              taco-egress-gateway: enabled
+    pilot:
+      traceSampling: 1.0
+      resources:
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      nodeSelector:
+        servicemesh: enabled
+    revision: ""
+    revisionTags: []
+    global:
+      istioNamespace: istio-system
+      defaultResources:
+        requests:
+          cpu: 10m
+          memory: 128Mi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+      hub: docker.io/istio
+      tag: 1.13.1
+      proxy:
+        image: proxyv2
+        autoInject: enabled
+        clusterDomain: "cluster.local"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+        tracer: "zipkin"
+      tracer:
+        zipkin: 
+          address: "jaeger-operator-jaeger-collector.istio-system:9411"
+  wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: istio-ingress-gateway
+  name: istio-ingress-gateway
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://openinfradev.github.io/helm-repo
+    name: istio-ingress-gateway
+    version: 1.13.1
+  releaseName: istio-ingress-gateway
+  targetNamespace: istio-ingress
+  values:
+    revision: ""
+    replicaCount: 1
+    service:
+      type: LoadBalancer
+      ports:
+      - name: status-port
+        port: 15021
+        protocol: TCP
+        targetPort: 15021
+      - name: http2
+        port: 80
+        protocol: TCP
+        targetPort: 80
+      - name: https
+        port: 443
+        protocol: TCP
+        targetPort: 443
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1024Mi
+      limits:
+        cpu: 2000m
+        memory: 2048Mi
+    labels:
+      app: istio-ingress-gateway
+    nodeSelector:
+      taco-ingress-gateway: enabled
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -180,10 +129,11 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: jaeger-operator
-    version: 2.23.0
+    version: 2.27.1
   releaseName: jaeger-operator-crds
   targetNamespace: istio-system
   values: {}
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -196,7 +146,7 @@ spec:
   chart:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
-    version: 2.23.0
+    version: 2.27.1
     name: jaeger-operator
   releaseName: jaeger-operator
   targetNamespace: istio-system
@@ -204,11 +154,9 @@ spec:
     jaeger:
       create: false
       namespace: istio-system
-    rbac:
-      create: true
-      clusterRole: true
     nodeSelector:
       servicemesh: enabled
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -222,13 +170,14 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: servicemesh-jaeger-resource
-    version: 2.21.2
+    version: 2.27.1
   releaseName: servicemesh-jaeger-resource
   targetNamespace: istio-system
   values:
     namespace: istio-system
     strategy: production
-    logLevel: debug
+    sampling:
+      param: 100
     ingress:
       enabled: false
     collector:
@@ -238,7 +187,7 @@ spec:
           cpu: 500m
           memory: 1Gi
         limits:
-          cpu: '1'
+          cpu: 1000m
           memory: 2Gi
     storage:
       esIndexCleaner:
@@ -247,26 +196,26 @@ spec:
         schedule: "55 04 * * *"
       options:
         es:
-          index-prefix: jaeger
-          username: TO_BE_FIXED
-          password: TO_BE_FIXED
+          indexPrefix: jaeger
+          username: elastic
+          password: tacoword
           tlsCa: /etc/ssl/certs/tls.crt
-          serverUrls: https://eck-elasticsearch-es-http.lma.svc:9200
+          serverUrls: https://eck-elasticsearch-es-http.elastic-system.svc:9200
           secretName: eck-elasticsearch-es-http-certs-public
-    JaegerIngress:
-      enabled: true
-      namespace: istio-system
-      rules:
-      - host: jaeger.k2-node01
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: jaeger-operator-jaeger-query
-                port:
-                  number: 16686
+    query:
+      basePath: /
+    elasticsearch:
+      image:
+        repository: docker.io/openstackhelm/heat
+        tag: newton
+        pullPolicy: IfNotPresent
+      host: eck-elasticsearch-es-http.lma.svc.cluster.local
+      port: 9200
+      elasticPasswordSecret: eck-elasticsearch-es-elastic-user
+      user:
+        enabled: true
+        username: taco-jaeger
+        password: tacoword
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -281,10 +230,11 @@ spec:
     type: helmrepo
     repository: https://kiali.org/helm-charts
     name: kiali-operator
-    version: 1.38.1
+    version: 1.45.1
   releaseName: kiali-operator-crds
   targetNamespace: istio-system
   values: {}
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -298,15 +248,25 @@ spec:
     type: helmrepo
     repository: https://kiali.org/helm-charts
     name: kiali-operator
-    version: 1.38.1
+    version: 1.45.1
   releaseName: kiali-operator
   targetNamespace: istio-system
   values:
+    image:
+      repo: quay.io/kiali/kiali-operator
+      tag: v1.45.1
     nodeSelector:
       servicemesh: enabled
-    clusterRoleCreator: true
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "64Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
     cr:
       create: false
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -320,18 +280,15 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: servicemesh-kiali-resource
-    version: 1.34.0
+    version: 1.45.1
   releaseName: servicemesh-kiali-resource
   targetNamespace: istio-system
   values:
-    nameOverride: "kiali"
-    fullnameOverride: "kiali"
-    istioComponentNamespaces:
-      prometheus: lma
+    namespace: istio-system
     istioNamespace: istio-system
     deployment:
-      accessible_namespaces:
-      - '**'
+      ingress:
+        enabled: false
       namespace: istio-system
       replicas: 1
       resources:
@@ -339,54 +296,51 @@ spec:
           cpu: 500m
           memory: 512Mi
         limits:
-          cpu: 500m
+          cpu: 1000m
           memory: 1024Mi
+      replicas: 1
       nodeSelector:
         servicemesh: enabled
       serviceType: ClusterIP
+      additionalServiceYaml:
+        nodePort: 30010
     auth:
       strategy: anonymous
     externalServices:
       customDashboards:
         enabled: true
       istio:
-        configMapName: istio-1-11-7
+        configMapName: "istio"
         istioIdentityDomain: "svc.cluster.local"
+        componentStatus:
+          enabled: true
+          components:
+            istiodLabel: istiod
+            ingressGatewayLabel: istio-ingress-gateway
+            egressGatewayLabel: istio-egress-gateway
       prometheus:
-        url: http://prometheus-kube-prometheus-prometheus.prometheus.svc:9090
+        url: http://lma-prometheus.lma.svc:9090
       tracing:
         enabled: true
         namespaceSelector: true
         inClusterUrl: http://jaeger-operator-jaeger-query.istio-system:16686
+        url: https://jaeger-v2.taco-cat.xyz
+        useGrpc: false
       grafana:
         auth:
-          password: TO_BE_FIXED
+          password: password
           type: basic
           useKialiToken: false
-          username: TO_BE_FIXED
+          username: admin
         enabled: true
-        inClusterUrl: http://grafana.istio-system.svc:3000
-        url: http://k1-master01:30099
+        inClusterUrl: http://grafana.lma.svc:3000
+        url: https://grafana-v2.taco-cat.xyz
     server:
       metricsEnabled: true
       metricsPort: 9090
       port: 20001
       webRoot: /kiali
-    KialiIngress:
-      enabled: true
-      namespace: istio-system
-      rules:
-      - host: kiali.k2-node01
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kiali
-                port:
-                  number: 20001
-
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -400,12 +354,14 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: servicemesh-grafana-dashboard
-    version: 1.7.0
+    version: 1.13.1
   releaseName: servicemesh-grafana-dashboard
   targetNamespace: istio-system
   values:
     namespace: istio-system
-
+    dashboards:
+      label: grafana_dashboard
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -428,7 +384,7 @@ spec:
       interval: "15s"
     jaeger:
       interval: "15s"
-
+  wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -451,3 +407,4 @@ spec:
       interval: "5s"
     optimization:
       interval: "5s"
+  wait: true

--- a/service-mesh/base/site-values.yaml
+++ b/service-mesh/base/site-values.yaml
@@ -4,67 +4,40 @@ metadata:
   name: site
 
 global:
+  clusterName: cluster.local
   serviceMeshControlNodeSelector:
     servicemesh: enabled
   serviceMeshIngressNodeSelector:
     taco-ingress-gateway: enabled
   serviceMeshEgressNodeSelector:
     taco-egress-gateway: enabled
-  ingressGatewayLabel:
-    gateway: taco-ingress
-  egressGatewayLabel:
-    gateway: taco-egress
-  clusterName: cluster.local
-  storageClassName: taco-storage
+  ingressGatewayLabel: istio-ingress-gateway
+  egressGatewayLabel: istio-egress-gateway
 
 charts:
-- name: istio-operator
-  override:
-    revision: "1-11-7"
-    operator.resources.limits.cpu: 200m
-    operator.resources.limits.memory: 256Mi
-    operator.resources.requests.cpu: 50m
-    operator.resources.requests.memory: 128Mi
+- name: istio-base
+  override: {}
 
-- name: servicemesh-controlplane
+- name: istiod
   override:
-    IstioOperator.revision: "1-11-7"
-    IstioOperator.meshConfig.enableTracing: true
-    IstioOperator.meshConfig.tracingSampling: 100
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.service: jaeger-operator-jaeger-collector.istio-system.svc
-    IstioOperator.meshConfig.extensionProviders.envoyExtAuthzGrpc.port: 14250
-    IstioOperator.meshConfig.defaultConfig.discoveryAddress: istiod-1-11-7.istio-system.svc:15012
-    IstioOperator.meshConfig.defaultConfig.tracing.zipkin.address: jaeger-operator-jaeger-collector.istio-system.svc:9411
-    IstioOperator.meshConfig.defaultConfig.tracing.sampling: 100
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.pilot.k8s.resources.requests.cpu: 1000m
-    IstioOperator.components.pilot.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.pilot.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.pilot.k8s.nodeSelector: $(serviceMeshControlNodeSelector)
+    revision: ""
+    pilot.traceSampling: 1.0
+    pilot.resources.requests.cpu: 500m
+    pilot.resources.requests.memory: 2048Mi
+    pilot.nodeSelector: $(serviceMeshControlNodeSelector)
+    global.tracer.zipkin.address: "jaeger-operator-jaeger-collector.istio-system:9411"
 
-- name: servicemesh-gateway
+- name: istio-ingress-gateway
   override:
-    IstioOperator.revision: "1-11-7"
-    IstioOperator.values.global.istioNamespace: istio-system
-    IstioOperator.components.ingressGateways.name: istio-ingress-gateway
-    IstioOperator.components.ingressGateways.namespace: istio-system
-    IstioOperator.components.ingressGateways.label: $(ingressGatewayLabel)
-    IstioOperator.components.ingressGateways.enabled: true
-    IstioOperator.components.ingressGateways.k8s.resources.requests.cpu: 1000m
-    IstioOperator.components.ingressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.ingressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.ingressGateways.k8s.nodeSelector: $(serviceMeshIngressNodeSelector)
-    IstioOperator.components.ingressGateways.k8s.service.type: NodePort
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpNodePort: 31081
-    IstioOperator.components.ingressGateways.k8s.service.ports.httpsNodePort: 31443
-    IstioOperator.components.egressGateways.name: istio-egress-gateway
-    IstioOperator.components.egressGateways.namespace: istio-system
-    IstioOperator.components.egressGateways.label: $(egressGatewayLabel)
-    IstioOperator.components.egressGateways.enabled: false
-    IstioOperator.components.egressGateways.k8s.resources.requests.cpu: 1000m
-    IstioOperator.components.egressGateways.k8s.resources.requests.memory: 1024Mi
-    IstioOperator.components.egressGateways.k8s.hpaSpec.minReplicas: 1
-    IstioOperator.components.egressGateways.k8s.nodeSelector: $(serviceMeshEgressNodeSelector)
+    revision: ""
+    replicaCount: 1
+    service.type: LoadBalancer
+    resources.requests.cpu: 1000m
+    resources.requests.memory: 1024Mi
+    resources.limits.cpu: 2000m
+    resources.limits.memory: 2048Mi
+    labels.app: $(ingressGatewayLabel)
+    nodeSelector: $(serviceMeshIngressNodeSelector)
 
 - name: jaeger-operator
   override:
@@ -73,29 +46,20 @@ charts:
 - name: servicemesh-jaeger-resource
   override:
     namespace: istio-system
-    logLevel: debug
+    sampling.param: 100
     collector.resources.requests.cpu: 500m
-    collector.resources.requests.memory: 1Gi
-    collector.resources.limits.cpu: '1'
-    collector.resources.limits.memory: 2Gi
+    collector.resources.requests.memory: 1024Mi
+    collector.resources.limits.cpu: 1000m
+    collector.resources.limits.memory: 2048Mi
     storage.options.es:
       serverUrls: https://eck-elasticsearch-es-http.lma.svc:9200
       username: elastic
       password: tacoword
-    JaegerIngress:
-      enabled: false
-      namespace: istio-system
-      rules:
-      - host: jaeger.k2-node01
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: jaeger-operator-jaeger-query
-                port:
-                  number: 16686
+    elasticsearch:
+      host: eck-elasticsearch-es-http.lma.svc.$(clusterName)
+      user:
+        username: taco-jaeger
+        password: tacoword
 
 - name: kiali-operator
   override:
@@ -103,39 +67,30 @@ charts:
 
 - name: servicemesh-kiali-resource
   override:
-    istioComponentNamespaces.prometheus: lma
+    namespace: istio-system
     istioNamespace: istio-system
     deployment.resources.requests.cpu: 500m
-    deployment.resources.requests.memory: 1024Mi
+    deployment.resources.requests.memory: 512Mi
     deployment.resources.limits.cpu: 1000m
-    deployment.resources.limits.memory: 2048Mi
+    deployment.resources.limits.memory: 1024Mi
     deployment.nodeSelector: $(serviceMeshControlNodeSelector)
-    externalServices.istio.configMapName: istio-1-11-7
-    externalServices.istio.istioIdentityDomain: "svc.cluster.local"
+    auth.strategy: anonymous
+    externalServices.istio.configMapName: istio
+    externalServices.istio.istioIdentityDomain: svc.$(clusterName)
     externalServices.prometheus.url: http://lma-prometheus.lma.svc:9090
     externalServices.tracing.inClusterUrl: http://jaeger-operator-jaeger-query.istio-system:16686
+    externalServices.tracing.url: https://jaeger-v2.taco-cat.xyz
+    externalServices.tracing.useGrpc: false
+    externalServices.grafana.auth.type: basic
     externalServices.grafana.auth.username: admin
     externalServices.grafana.auth.password: password
     externalServices.grafana.inClusterUrl: http://grafana.lma.svc:80
-    externalServices.grafana.url: http://k1-master01:30009
-    KialiIngress:
-      enabled: false
-      namespace: istio-system
-      rules:
-      - host: kiali.k2-node01
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: kaili
-                port:
-                  number: 20001
+    externalServices.grafana.url: https://grafana-v2.taco-cat.xyz
 
 - name: servicemesh-grafana-dashboard
   override:
     namespace: istio-system
+    dashboards.label: grafana_dashboard
 
 - name: servicemesh-prometheusmonitor
   override:

--- a/service-mesh/image/image-values.yaml
+++ b/service-mesh/image/image-values.yaml
@@ -6,50 +6,32 @@ global:
   registry: LOCAL_REGISTRY
 
 charts:
-- name: istio-operator
+- name: istiod
   override:
-    hub: $(registry)/istio-testing
-    tag: latest
+    hub: $(registry)/istio/pilot
+    tag: 1.13.1
 
-- name: servicemesh-controlplane
-  override: 
-    IstioOperator.image.hub: $(registry)/istio-testing
-    IstioOperator.image.tag: 1.14-alpha.82cbd49db92acce69184ab4e9b95e033ea8ab390
-
-- name: servicemesh-gateway
+- name: istio-ingress-gateway
   override:
-    IstioOperator.image.hub: $(registry)/istio-testing
-    IstioOperator.image.tag: 1.14-alpha.82cbd49db92acce69184ab4e9b95e033ea8ab390
+    hub: $(registry)/istio/proxyv2
+    tag: 1.13.1
 
 - name: jaeger-operator
   override:
     image.repository: $(registry)/jaegertracing/jaeger-operator
-    image.tag: 1.24.0
+    image.tag: 1.29.1
     collectorImage.repository: $(registry)/jaegertracing/jaeger-collector
-    collectorImage.tag: 1.24.0
+    collectorImage.tag: 1.29.1
     agentImage.repository: $(registry)/jaegertracing/jaeger-agent
-    agentImage.tag: 1.24.0
+    agentImage.tag: 1.29.1
     ingesterImage.repository: $(registry)/jaegertracing/jaeger-ingester
-    ingesterImage.tag: 1.24.0
+    ingesterImage.tag: 1.29.1
     queryImage.repository: $(registry)/jaegertracing/jaeger-collector
-    queryImage.tag: 1.24.0
-
-- name: servicemesh-jaeger-resource
-  override:
-    image.repository: $(registry)/jaegertracing/jaeger-operator
-    image.tag: 1.24.0
-    collectorImage.repository: $(registry)/jaegertracing/jaeger-collector
-    collectorImage.tag: 1.24.0
-    agentImage.repository: $(registry)/jaegertracing/jaeger-agent
-    agentImage.tag: 1.24.0
-    ingesterImage.repository: $(registry)/jaegertracing/jaeger-ingester
-    ingesterImage.tag: 1.24.0
-    queryImage.repository: $(registry)/jaegertracing/jaeger-collector
-    queryImage.tag: 1.24.0
+    queryImage.tag: 1.29.1
 
 - name: kiali-operator
   override:
     image.repo: $(registry)/kiali/kiali-operator
-    image.tag: v1.38.1
+    image.tag: v1.45.1
 
 


### PR DESCRIPTION
Change istio operator to istio helm charts

Upgrade charts
- istio-1.13.1
- jaeger-operator-2.27.1 (app: v1.29.1)
- kiali-operator-1.45.1 (app: v1.45.1)
- istio-grafana-dashboard-1.13.1 

