### PR TITLE
lma: prometheus: fix kubeetcd endpoints

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -182,7 +182,7 @@ spec:
         interval: TO_BE_FIXED
     kubeEtcd:
       enabled: true
-      endpoints: [] # TO_BE_FIXED
+      endpoints: []
       serviceMonitor:
         interval: TO_BE_FIXED
         caFile: /etc/prometheus/secrets/etcd-client-cert/etcd-ca

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -29,7 +29,7 @@ charts:
 
 - name: prometheus
   override:
-    kubeEtcd.endpoints: [TO_BE_FIXED]
+    kubeEtcd.endpoints: [] # If your etcd is not deployed as a pod, specify IPs it can be found on
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.storageClassName: $(storageClassName)
     # Define specifications for storing metrics
     prometheus.prometheusSpec.storageSpec.volumeClaimTemplate.spec.resources.requests.storage: 200Gi


### PR DESCRIPTION
kube-prometheus-stack 차트는 POD로 실행되는 etcd의 exporter 아이피를 서비스 셀렉터를 통해 자동 구성하는 방법을 지원합니다. 이를 위해 kubeEtcd.endpoints 리스트가 비어 있어야 하기 때문에 해당 내용으로 정리하였습니다.