### PR TITLE
disable dns discovery of thanos sidecar service

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -929,7 +929,7 @@ spec:
     query:
       nodeSelector: {}
       dnsDiscovery:
-        enabled: true
+        enabled: false
         sidecarsService: TO_BE_FIXED
         sidecarsNamespace: lma
     queryFrontend:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -175,9 +175,11 @@ charts:
     clusterDomain: $(clusterName)
     existingObjstoreSecret: $(thanosObjstoreSecret)
     query.nodeSelector: $(nodeSelector)
-    query.dnsDiscovery.sidecarsService: lma-thanos-discovery
+    # Example of dns discovery for thanos sidecar service:
     # query.stores:
     #   - lma-thanos-discovery.lma.svc.$(clusterName)
+    query.dnsDiscovery.enabled: false
+    query.dnsDiscovery.sidecarsService: null
     queryFrontend.nodeSelector: $(nodeSelector)
     queryFrontend.service.type: NodePort
     queryFrontend.service.http.nodePort: 30007


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/221

thanos에서 타 클러스터의 sidecar LB endpoint를 직접 참조하므로, 사용하지 않는 dns discovery 기능을 disable합니다.