### PR TITLE
lma: use downstream charts for thanos and kube-state-metrics

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -303,7 +303,7 @@ spec:
     #    - https://github.com/kubernetes/kube-state-metrics/issues/1337
     #    - https://github.com/kubernetes/kube-state-metrics/issues/1342
     # so, i'll use bitnami before the issues are closed
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://openinfradev.github.io/helm-repo
     name: kube-state-metrics
     # version: 2.9.4
     version: 1.1.3
@@ -916,7 +916,7 @@ spec:
   helmVersion: v3
   chart:
     type: helmrepo
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://openinfradev.github.io/helm-repo
     name: thanos
     version: 3.4.0
   releaseName: thanos


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/125 반영된 내용을 사용하기 위해 kube-state-metrics와 thanos 차트 저장소를 openinfradev로 변경합니다.