### PR TITLE
lma.fluentbit: support multiline and multi-es

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -610,7 +610,7 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: fluentbit-operator
-    version: 1.2.1
+    version: 1.3.0
     skipDepUpdate: true
   releaseName: fluentbit
   targetNamespace: lma
@@ -644,6 +644,8 @@ spec:
         memBufLimit: 20MB
         bufferChunkSize: 2M
         bufferMaxSize: 5M
+        extraArgs:
+          multilineParser: docker, cri
         multi_index:
         - key: "$kubernetes['namespace_name']"
           value: "kube-system|lma|fed|argo|openstack"
@@ -662,13 +664,13 @@ spec:
         parser: syslog-rfc5424
       outputs:
         es:
-          enabled: true
-          createuser: true
-          elasticPasswordSecret: TO_BE_FIXED
-          username: taco-fluentbit
-          password: tacoword
+        - name: taco-es
           host: TO_BE_FIXED
           port: 9200
+          createuser: true
+          username: taco-fluentbit
+          password: tacoword
+          elasticPasswordSecret: TO_BE_FIXED
           template:
             enabled: true
             ilms:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -130,8 +130,8 @@ charts:
     fluentbit.clusterName: $(clusterName)
 
     # Define a endpoint to store logs
-    fluentbit.outputs.es.host: eck-elasticsearch-es-http.lma.svc.$(clusterName)
-    fluentbit.outputs.es.elasticPasswordSecret: eck-elasticsearch-es-elastic-user
+    fluentbit.outputs.es[1].host: eck-elasticsearch-es-http.lma.svc.$(clusterName)
+    fluentbit.outputs.es[1].elasticPasswordSecret: eck-elasticsearch-es-elastic-user
     fluentbit.outputs.kafka:
       enabled: false
       broker: "YOUR_BORKER_INFO"


### PR DESCRIPTION
multiline을 지원하는 paser를 enable하고 요구사항에 의해 개발된 다수의 es클러스터를 지원하는 1.3.0챠트를 사용하도록 함