### PR TITLE
Loki production

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1050,6 +1050,9 @@ spec:
           ingestion_burst_size_mb: 1024
           max_streams_per_user: 0
           max_global_streams_per_user: 0
+        table_manager:
+          retention_deletes_enabled: true
+          retention_period: TO_BE_FIXED
     serviceMonitor.enabled: true
     prometheusRule.enabled: true
     ingester:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1060,6 +1060,10 @@ spec:
         requests:
           cpu: 100m
           memory: 250Mi
+      persistence:
+        enabled: true
+        inMemory: false
+        size: 100Gi
     memcachedExporter.enabled: true
 ---
 apiVersion: helm.fluxcd.io/v1

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1041,7 +1041,9 @@ spec:
           cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
           shared_store: s3
         aws:
-          s3: s3://ap-northeast-2/taco-loki-entire-cluster
+          s3: TO_BE_FIXED
+          bucketnames: loki
+          s3forcepathstyle: true
       structuredConfig:
         limits_config:
           ingestion_rate_mb: 1024
@@ -1051,17 +1053,6 @@ spec:
     serviceMonitor.enabled: true
     prometheusRule.enabled: true
     ingester:
-      extraEnv:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_SECRET_ACCESS_KEY
       resources:
         limits:
           cpu: '4'
@@ -1069,42 +1060,6 @@ spec:
         requests:
           cpu: 100m
           memory: 250Mi
-    querier:
-      extraEnv:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_SECRET_ACCESS_KEY
-    compactor:
-      extraEnv:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_SECRET_ACCESS_KEY
-    ruler:
-      extraEnv:
-      - name: AWS_ACCESS_KEY_ID
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_ACCESS_KEY_ID
-      - name: AWS_SECRET_ACCESS_KEY
-        valueFrom:
-          secretKeyRef:
-            name: iam-loki-s3
-            key: AWS_S3_SECRET_ACCESS_KEY
     memcachedExporter.enabled: true
 ---
 apiVersion: helm.fluxcd.io/v1

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1016,20 +1016,96 @@ spec:
   chart:
     type: helmrepo
     repository: https://grafana.github.io/helm-charts
-    name: loki
-    version: 2.8.1
+    name: loki-distributed 
+    version: 0.58.0
   releaseName: loki
   targetNamespace: lma
   values:
-    image:
-      tag: 2.4.1
-    replicas: 1
-    persistence:
-      enabled: true
-      size: 20Gi
-      storageClassName: taco-storage
-    serviceMonitor:
-      enabled: false
+    global:
+      clusterDomain: cluster.local # TO_BE_FIXED
+      dnsService: coredns
+    loki:
+      schemaConfig:
+        configs:
+        - from: 2020-09-07
+          store: boltdb-shipper
+          object_store: s3
+          schema: v11
+          index:
+            prefix: loki_index_
+            period: 24h
+      storageConfig:
+        boltdb_shipper:
+          active_index_directory: /var/loki/index
+          cache_location: /var/loki/cache
+          cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+          shared_store: s3
+        aws:
+          s3: s3://ap-northeast-2/taco-loki-entire-cluster
+      structuredConfig:
+        limits_config:
+          ingestion_rate_mb: 1024
+          ingestion_burst_size_mb: 1024
+          max_streams_per_user: 0
+          max_global_streams_per_user: 0
+    serviceMonitor.enabled: true
+    prometheusRule.enabled: true
+    ingester:
+      extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_SECRET_ACCESS_KEY
+      resources:
+        limits:
+          cpu: '4'
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 250Mi
+    querier:
+      extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_SECRET_ACCESS_KEY
+    compactor:
+      extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_SECRET_ACCESS_KEY
+    ruler:
+      extraEnv:
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_ACCESS_KEY_ID
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: iam-loki-s3
+            key: AWS_S3_SECRET_ACCESS_KEY
+    memcachedExporter.enabled: true
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1046,8 +1046,8 @@ spec:
           s3forcepathstyle: true
       structuredConfig:
         limits_config:
-          ingestion_rate_mb: 1024
-          ingestion_burst_size_mb: 1024
+          ingestion_rate_mb: 25
+          ingestion_burst_size_mb: 50
           max_streams_per_user: 0
           max_global_streams_per_user: 0
         table_manager:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -235,6 +235,7 @@ charts:
 - name: loki
   override:
     loki.storageConfig.aws.s3: http://$(defaultUser):$(defaultPassword)@thanos-minio.lma.svc:9000/minio
+    loki.structuredConfig.table_manager.retention_period: 672h    # delete logs after 672h = 28 days
 
 - name: promtail
   override:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -215,7 +215,7 @@ charts:
     ruler.persistence.size: 8Gi
     minio.accessKey.password: $(defaultUser)
     minio.secretKey.password: $(defaultPassword)
-    minio.defaultBuckets: thanos
+    minio.defaultBuckets: "thanos, loki"
     minio.persistence.storageClass: $(storageClassName)
     minio.persistence.accessMode: ReadWriteOnce
     minio.persistence.size: 8Gi
@@ -230,14 +230,11 @@ charts:
       secretName: $(thanosObjstoreSecret)
     sidecarsService.name: thanos-sidecars
     sidecarsService.endpoints: 
-      - 172.16.50.114
+      - 127.0.0.1
 
 - name: loki
   override:
-    replicas: 1
-    persistence.size: 20Gi
-    persistence.storageClassName: $(storageClassName)
-    serviceMonitor.enabled: false
+    loki.storageConfig.aws.s3: http://$(defaultUser):$(defaultPassword)@thanos-minio.lma.svc:9000/minio
 
 - name: promtail
   override:


### PR DESCRIPTION
Loki 상용환경을 위한 형상정의 및 적용

1. chart변경: form single-mode to micro service mode
2. 맞춰서 값지정
3. loki의 obj store로 minio 사용하도록 변경 (thanos에서 설치하는 minio)

cf. commit중 첫번째 부분은 s3 활용을 위해 시도했던 부분으로 몇몇 이유에 의해 현재 활용 불가한 상황을 포함함.. 추후 s3를 활용할 경우 참고 할수 있도록 남겨둠.