### PR TITLE
loki: add nginx config to recieve massive data

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1077,6 +1077,12 @@ spec:
         inMemory: false
         size: 100Gi
     memcachedExporter.enabled: true
+    gateway:
+      nginxConfig:
+        httpSnippet: |-
+          client_max_body_size 50M;
+        serverSnippet: |-
+          client_max_body_size 50M;
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease


### PR DESCRIPTION
log수집에서 지속적인 에러가 발생
```
[2022/12/01 06:51:41] [error] [output:loki:loki.0] loki-loki-distributed-gateway.lma.svc:80, HTTP status=413
<html>
<head><title>413 Request Entity Too Large</title></head>
<body>
<center><h1>413 Request Entity Too Large</h1></center>
<hr><center>nginx/1.19.10</center>
</body>
</html>
```

이를 해결하기 위한 loki의 frontend 설정 추가하는 내역
loki의 내부 컴포넌트간 처리도 필요하지만 그렇게 하기위해서는 챠트구조가 매우 많은 부분을 override해야함.
테스트 환경에서 현재 플랫폼 로그(kube-system/taco-system/lma/istio...)에 대해서는 해결되는 것처럼 보이므로 일단 pr
내부 컴포넌트간 문제가 발생시 새로운 PR로 대응할 예정 

### 원인 상세
- fluentbit에 버퍼에 쌓인 데이터를 주기적으로 넣으면서 1M인 기본 제한을 넘겨 데이터를 올리는 경우가 발생
- 한번 밀리기 시작하면 지속적으로 발생하고 fluentbit은 로그수집을 정지했다 시작했다를 반복함
- fluentbit의 컴포넌트별로 이상동작을 발생시킴
  - emitter error등 
```
[2022/12/01 06:54:47] [error] [input:emitter:alertrule_match] error registering chunk with tag: seperate-kube-0.kube.var.log.containers.cilium-operator-c6b98d54d-qt55m_kube-system_cilium-operator-db8d6f40ec99084f9dfb2a6addcf0b2d555c7acc434f452f3358e4068532dc9a.log
[2022/12/01 06:54:47] [error] [input:emitter:alertrule_match] error registering chunk with tag: seperate-kube-0.kube.var.log.containers.prometheus-lma-prometheus-0_lma_prometheus-50cc8311e6292f2994b70ee5d41609fc14f30932c285ace8217a68d89d020605.log
```