### PR TITLE
clustar-api-aws 정적 워커 노드 배포

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -11,7 +11,7 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: cluster-api-aws
-    version: 0.6.0
+    version: 0.7.0
   releaseName: cluster-api-aws
   targetNamespace: argo
   values:

--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -37,19 +37,6 @@ spec:
         type: gp2
     machinePool: []
     machineDeployment: []
-    job:
-      taconode:
-        enabled: true
-        labels:
-        - taco-lma
-        - taco-ingress-gateway
-        - taco-egress-gateway
-        - servicemesh
-      argo:
-        enabled: true
-        url: TO_BE_FIXED  # argocd url like argocd-v2.taco-cat.xyz
-        user: admin
-        password: TO_BE_FIXED  
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/165 사용을 위해 차트 버전을 업데이트 합니다.