### PR TITLE
feature: Change minio values to support Arm64 platform openinfradev/tks-issues#500

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -651,9 +651,9 @@ spec:
       - key: $kubernetes['container_name']
         value: kibana|elasticsearch|fluent-bit
     logExporter:
-      enabled: true
+      enabled: false
       serviceMonitor:
-        enabled: true
+        enabled: false
       spec:
         nodeSelector:
           taco-lma: enabled
@@ -800,22 +800,17 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: minio
-    version: 6.8.3
+    version: 5.0.4
   releaseName: minio
   targetNamespace: lma
-  values:
-    accessKey:
-      password: TO_BE_FIXED
-    secretKey:
-      password: TO_BE_FIXED
-    defaultBuckets: TO_BE_FIXED
-    service:
-      type: NodePort
-      nodePort: 30002
+  values: 
+    users: [] # must_be_defined
+    buckets: [] # must_be_defined
     persistence:
-      storageClass: TO_BE_FIXED
-      accessMode: TO_BE_FIXED
-      size: TO_BE_FIXED
+      storageClass: # must_be_defined
+      accessMode: ReadWriteOnce
+      size: 20Gi # tunable 
+    mode: standalone   
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -804,13 +804,13 @@ spec:
   releaseName: minio
   targetNamespace: lma
   values: 
-    users: [] # must_be_defined
-    buckets: [] # must_be_defined
+    users: [] # MUST_BE_DEFINED
+    buckets: [] # MUST_BE_DEFINED
     persistence:
-      storageClass: # must_be_defined
-      accessMode: ReadWriteOnce
+      storageClass: MUST_BE_DEFINED
+      accessMode: ReadWriteOnce # tunable
       size: 20Gi # tunable 
-    mode: standalone   
+    mode: standalone
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -156,12 +156,24 @@ charts:
 
 - name: minio
   override:
-    accessKey.password: $(defaultUser)
-    secretKey.password: $(defaultPassword)
-    defaultBuckets: "thanos, loki"
+    users:
+      - accessKey: $(defaultUser)
+        secretKey: $(defaultPassword)
+        policy: consoleAdmin 
+    buckets:
+      - name: thanos
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
+      - name: loki
+        policy: public
+        purge: false
+        versioning: true
+        objectlocking: false
     persistence.storageClass: $(storageClassName)
     persistence.accessMode: ReadWriteOnce
-    persistence.size: 8Gi
+    persistence.size: 20Gi
 
 - name: thanos
   override:


### PR DESCRIPTION
- 배경:
  -  Arm64 플랫폼 지원을 위해 minio-official/minio의 helm chart를 사용 예정 
- 수정사항:
  - minio resource
    - bitnami/minio Chart 기반 -> minio-official/minio Chart 기반으로 수정
    - Bucket ( /loki 와 /grafana )이 정상 생성되도록 user 추가
  - fluentbit resource
    - (logalert-exporter) enabled 필드 값을 false로 수정