### PR TITLE
update cluster-api-aws to 0.8.0 for EKS

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -11,7 +11,7 @@ spec:
     type: helmrepo
     repository: https://openinfradev.github.io/helm-repo
     name: cluster-api-aws
-    version: 0.7.0
+    version: 0.8.0
   releaseName: cluster-api-aws
   targetNamespace: argo
   values:


### PR DESCRIPTION
cluster-api-aws Helm 차트 버전을 EKS 지원이 추가된  0.8.0으로 업데이트하였습니다.
- 참고: https://github.com/openinfradev/helm-charts/pull/166