### PR TITLE
change default for single cluster

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -862,7 +862,7 @@ spec:
         # query-range.max-retries-per-request: TO_BE_FIXED
         # query-frontend.log-queries-longer-than: TO_BE_FIXED
     bucketweb:
-      enabled: TO_BE_FIXED
+      enabled: true
       logLevel: info
       refresh: 30m
       timeout: 5m
@@ -872,7 +872,7 @@ spec:
         http:
           port: 8080
     compactor:
-      enabled: TO_BE_FIXED
+      enabled: true
       logLevel: info
       retentionResolutionRaw: TO_BE_FIXED
       retentionResolution5m: TO_BE_FIXED
@@ -931,7 +931,7 @@ spec:
         #  targetCPU: 50
         #  targetMemory: 50
     ruler:
-      enabled: TO_BE_FIXED
+      enabled: true
       logLevel: info
       alertmanagers: [] # TO_BE_FIXED
       evalInterval: 1m

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -19,8 +19,9 @@ global:
   defaultUser: taco
   # Secret name to connect the object storage
   thanosObjstoreSecret: taco-objstore-secret
-  # Which it install every thanos component?
-  thanosPrimaryCluster: true
+
+  lokiHost: loki-loki-distributed-gateway
+  lokiPort: 80
 
 charts:
 - name: prometheus-operator
@@ -127,12 +128,6 @@ charts:
 
 - name: addons
   override:
-    # Configure the connection from prometheus to elasticsearch (It not used)
-    metricbeat.elasticsearch.host: https://eck-elasticsearch-es-http.lma.svc.$(clusterName):9200
-    metricbeat.kibana.host: eck-kibana-dashboard-kb-http.lma.svc.$(clusterName):5601
-    metricbeat.prometheus.hosts:
-    - thanos-query-frontend.lma.svc.$(clusterName):9090
-
     # Initialize the kibana index
     serviceMonitor.grafana.interval: $(serviceScrapeInterval)
     serviceMonitor.argocd.interval: $(serviceScrapeInterval)
@@ -145,6 +140,9 @@ charts:
     serviceMonitor.kubelet.interval: $(serviceScrapeInterval)
     serviceMonitor.istio.interval: $(serviceScrapeInterval)
     serviceMonitor.jaeger.interval: $(serviceScrapeInterval)
+    grafanaDatasource.prometheus.url: "lma-prometheus.lma:9090"
+    # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
+    grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 
 - name: prometheus-adapter
   override:
@@ -194,8 +192,6 @@ charts:
       - --query-range.max-retries-per-request=3
       - --query-frontend.log-queries-longer-than=60s
 
-    bucketweb.enabled: $(thanosPrimaryCluster)
-    compactor.enabled: $(thanosPrimaryCluster)
     compactor.retentionResolutionRaw: 30d
     compactor.retentionResolution5m: 30d
     compactor.retentionResolution1h: 10y
@@ -210,7 +206,6 @@ charts:
           max_size: 250MB
           max_item_size: 125MB
     storegateway.persistence.size: 8Gi
-    ruler.enabled: $(thanosPrimaryCluster)
     ruler.alertmanagers:
     - http://alertmanager-operated:9093
     ruler.config: |-


### PR DESCRIPTION
primary cluster의 적용을 위해 기반 형상을 정의 한다.

- 기본 형상을 single로 정의
  - prometheus <- grafana의 형태로 매트릭 조회
  - 클러스터내 loki <- grafana의 형태로 로그 조회
  - 위 설정관련 내역중 loki나 prometheus를 변수로 처리하여 primary 설정에서 해당 변수를 변경하여 처리할 수 있도록 함
- thanos형상도 하나로 통일 (primary 변수 제거)
  - 모든 클러스터는 연합형상을 갖고 있지만 primary로 지정한 클러스터에만 thanos 배포