### PR TITLE
minio: Reduce default request memory size 16->1GB

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -805,7 +805,12 @@ spec:
     persistence:
       storageClass: MUST_BE_DEFINED
       accessMode: ReadWriteOnce # tunable
-      size: 20Gi # tunable 
+      size: 20Gi # tunable
+    resources:
+      requests:
+          memory: 1Gi # tunable
+      limits:
+          memory: 2Gi # tunable
     mode: standalone
 ---
 apiVersion: helm.fluxcd.io/v1

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -172,6 +172,8 @@ charts:
     persistence.storageClass: $(storageClassName)
     persistence.accessMode: ReadWriteOnce
     persistence.size: 20Gi
+    resources.requests.memory: 1Gi
+    resources.limits.memory: 2Gi
 
 - name: thanos
   override:


### PR DESCRIPTION
기본 minio의 메모리 request값을 하향 조정함.
16Gb -> 1Gb