### PR TITLE
원본 Helm 이력 추적을 위한 url 추가

### DIFF
--- a/deprecated_admin-tools/base/resources.yaml
+++ b/deprecated_admin-tools/base/resources.yaml
@@ -11,6 +11,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: keycloak-operator
     version: 0.1.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: keycloak-operator
   targetNamespace: keycloak
   values:
@@ -28,6 +29,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: keycloak-operator
     version: 0.1.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: keycloak-operator-crds
   targetNamespace: keycloak
   values: {}
@@ -44,6 +46,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: keycloak-resources
     version: 0.1.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: keycloak-resources
   targetNamespace: keycloak
   values:

--- a/deprecated_cloud-console/base/resources.yaml
+++ b/deprecated_cloud-console/base/resources.yaml
@@ -11,6 +11,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: keycloak
     version: 8.2.2
+    origin: https://codecentric.github.io/helm-charts
   releaseName: keycloak
   targetNamespace: fed
   values:
@@ -60,6 +61,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: cloud-console
     version: 1.0.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: cloud-console
   targetNamespace: fed
   values:
@@ -71,6 +73,7 @@ spec:
         authkey: elastic:tacoword
       password: password
       username: taco
+      #config.service.proxyurl.format
       #config.service.proxyurl.format
       service:
         proxyportlist: 32001-32008
@@ -84,18 +87,18 @@ spec:
         rule: "yes"
       keycloak:
         enabled: "yes"
-        url: TO_BE_FIXED  
+        url: TO_BE_FIXED
         realm: TO_BE_FIXED
         clientId: cloud-console
         hasRealmRole1: lma_system
         hasRealmRole2: lma_app
         hasRealmRole3: lma_viewer
-        cacert: TO_BE_FIXED 
+        cacert: TO_BE_FIXED
       lenz:
-        url: TO_BE_FIXED  
+        url: TO_BE_FIXED
       extra:
         config: |-
-        
+
         sql: |-
 
     nodeSelector:

--- a/deprecated_openstack/base/resources.yaml
+++ b/deprecated_openstack/base/resources.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
@@ -1051,7 +1052,7 @@ spec:
     endpoints:
       baremetal:
         hosts:
-          public: 
+          public:
         port:
           api:
             public: 30511

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -11,6 +11,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
     version: 44.3.1
+    origin: https://prometheus-community.github.io/helm-charts
   helmVersion: v3
   releaseName: prometheus-operator-crds
   targetNamespace: lma
@@ -29,6 +30,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
     version: 44.3.1
+    origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus-operator
   targetNamespace: lma
   values:
@@ -106,6 +108,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
     version: 44.3.1
+    origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus
   targetNamespace: lma
   values:
@@ -294,6 +297,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: eck-operator
     version: 1.8.0
+    origin: https://helm.elastic.co
   releaseName: eck-operator
   targetNamespace: elastic-system
   values:
@@ -334,6 +338,7 @@ spec:
     name: kube-state-metrics
     # version: 2.9.4
     version: 3.2.8
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: kube-state-metrics
   targetNamespace: lma
   values:
@@ -357,6 +362,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: prometheus-node-exporter
     version: 4.13.0
+    origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus-node-exporter
   targetNamespace: lma
   values:
@@ -390,6 +396,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: prometheus-pushgateway
     version: 2.1.1
+    origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus-pushgateway
   targetNamespace: lma
   values:
@@ -416,6 +423,7 @@ spec:
     name: prometheus-process-exporter
     version: 0.1.4-skt
     skipDepUpdate: true
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: prometheus-process-exporter
   targetNamespace: lma
   values:
@@ -465,6 +473,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: eck-resource
     version: 1.1.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: eck-resource
   targetNamespace: lma
   values:
@@ -560,6 +569,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: grafana
     version: 6.50.7
+    origin: https://grafana.github.io/helm-charts
   releaseName: grafana
   targetNamespace: lma
   values:
@@ -617,6 +627,7 @@ spec:
     name: fluent-operator
     version: 1.7.0
     skipDepUpdate: true
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: fluent-operator-crds
   targetNamespace: lma
   values: {}
@@ -631,6 +642,7 @@ spec:
   helmVersion: v3
   chart:
     type: helmrepo
+    origin: https://openinfradev.github.io/helm-repo
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: fluent-operator
     version: 1.7.0
@@ -673,6 +685,7 @@ spec:
     name: fluentbit-resource
     version: 1.2.0
     skipDepUpdate: true
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: fluentbit
   targetNamespace: lma
   values:
@@ -745,6 +758,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: lma-addons
     version: 1.8.2
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: addons
   targetNamespace: lma
   values:
@@ -828,6 +842,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: prometheus-adapter
     version: 2.5.1
+    origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus-adapter
   targetNamespace: lma
   values:
@@ -855,6 +870,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kubernetes-event-exporter
     version: 2.0.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: kubernetes-event-exporter
   targetNamespace: lma
   values:
@@ -885,6 +901,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: minio
     version: 5.0.4
+    origin: https://charts.min.io
   releaseName: minio
   targetNamespace: lma
   values:
@@ -902,9 +919,9 @@ spec:
       size: 20Gi # tunable
     resources:
       requests:
-          memory: 1Gi # tunable
+        memory: 1Gi # tunable
       limits:
-          memory: 2Gi # tunable
+        memory: 2Gi # tunable
     mode: standalone
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -920,6 +937,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: thanos
     version: 3.4.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: thanos
   targetNamespace: lma
   values:
@@ -1068,6 +1086,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: thanos-config
     version: 0.1.4
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: thanos-config
   targetNamespace: lma
   values:
@@ -1100,6 +1119,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: prepare-etcd-secret
     version: 0.2.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: prepare-etcd-secret
   targetNamespace: lma
   values:
@@ -1134,6 +1154,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: loki-distributed
     version: 0.58.0
+    origin: https://grafana.github.io/helm-charts
   releaseName: loki
   targetNamespace: lma
   values:

--- a/sealed-secrets/base/resources.yaml
+++ b/sealed-secrets/base/resources.yaml
@@ -12,6 +12,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: sealed-secrets
     version: 1.16.1
+    origin: https://bitnami-labs.github.io/sealed-secrets
   releaseName: sealed-secrets-operator-crds
   targetNamespace: kube-system
   wait: true
@@ -30,6 +31,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: sealed-secrets
     version: 1.16.1
+    origin: https://bitnami-labs.github.io/sealed-secrets
   releaseName: sealed-secrets-operator
   targetNamespace: kube-system
   wait: true
@@ -48,6 +50,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kubed
     version: v0.12.0-rc.3
+    origin: https://charts.appscode.com/stable/
   releaseName: kubed
   targetNamespace: kube-system
   wait: true

--- a/service-mesh/base/resources.yaml
+++ b/service-mesh/base/resources.yaml
@@ -12,6 +12,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: istio-base
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: istio-base
   targetNamespace: istio-system
   values: {}
@@ -30,6 +31,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: istio-base
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: istio-base-crds
   targetNamespace: istio-system
   values: {}
@@ -48,6 +50,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: istiod
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: istiod
   targetNamespace: istio-system
   values:
@@ -85,7 +88,7 @@ spec:
             memory: 1024Mi
         tracer: "zipkin"
       tracer:
-        zipkin: 
+        zipkin:
           address: "jaeger-operator-jaeger-collector.istio-system:9411"
   wait: true
 ---
@@ -102,6 +105,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: istio-ingress-gateway
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: istio-ingress-gateway
   targetNamespace: istio-ingress
   values:
@@ -149,6 +153,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: istio-ingress-gateway
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: istio-egress-gateway
   targetNamespace: istio-ingress
   values:
@@ -196,6 +201,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: jaeger-operator
     version: 2.27.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: jaeger-operator-crds
   targetNamespace: istio-system
   values: {}
@@ -214,6 +220,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     version: 2.27.1
     name: jaeger-operator
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: jaeger-operator
   targetNamespace: istio-system
   values:
@@ -240,6 +247,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: servicemesh-jaeger-resource
     version: 2.27.2
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: servicemesh-jaeger-resource
   targetNamespace: istio-system
   values:
@@ -323,6 +331,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kiali-operator
     version: 1.45.1
+    origin: https://kiali.org/helm-charts
   releaseName: kiali-operator-crds
   targetNamespace: istio-system
   values: {}
@@ -341,6 +350,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kiali-operator
     version: 1.45.1
+    origin: https://kiali.org/helm-charts
   releaseName: kiali-operator
   targetNamespace: istio-system
   values:
@@ -374,6 +384,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: servicemesh-kiali-resource
     version: 1.45.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: servicemesh-kiali-resource
   targetNamespace: istio-system
   values:
@@ -449,6 +460,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: servicemesh-grafana-dashboard
     version: 1.13.1
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: servicemesh-grafana-dashboard
   targetNamespace: istio-system
   values:
@@ -470,6 +482,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: servicemesh-prometheusmonitor
     version: 1.7.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: servicemesh-prometheusmonitor
   targetNamespace: istio-system
   values:
@@ -493,6 +506,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: servicemesh-prometheusrule
     version: 1.7.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: servicemesh-prometheusrule
   targetNamespace: istio-system
   values:

--- a/tks-cluster/base/resources.yaml
+++ b/tks-cluster/base/resources.yaml
@@ -12,6 +12,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kubernetes-addons
     version: 0.1.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: kubernetes-addons
   targetNamespace: taco-system
   values:
@@ -35,6 +36,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: local-path-provisioner
     version: 0.0.22
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: local-path-provisioner
   targetNamespace: taco-system
   values:
@@ -55,6 +57,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: ingress-nginx
     version: 4.0.17
+    origin: https://kubernetes.github.io/ingress-nginx
   releaseName: ingress-nginx
   targetNamespace: taco-system
   values:
@@ -97,7 +100,7 @@ spec:
 #   helmVersion: v3
 #   chart:
 #     type: helmrepo
-#     repository: 
+#     repository:
 #     name: kubeseal
 #     version: 0.1.0
 #   releaseName: kubeseal
@@ -110,7 +113,7 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: kubed 
+    name: kubed
   name: kubed
 spec:
   helmVersion: v3
@@ -119,6 +122,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kubed
     version: v0.12.0
+    origin: https://charts.appscode.com/stable
   releaseName: kubed
   targetNamespace: taco-system
   values:
@@ -138,6 +142,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: cluster-autoscaler
     version: 0.2.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: cluster-autoscaler
   targetNamespace: kube-system
   values:
@@ -160,6 +165,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: cluster-autoscaler
     version: 0.2.0
+    origin: https://openinfradev.github.io/helm-repo
   releaseName: cluster-autoscaler-rbac
   targetNamespace: argo
   values:
@@ -181,6 +187,7 @@ spec:
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: metrics-server
     version: 3.8.2
+    origin: https://kubernetes-sigs.github.io/metrics-server/
   releaseName: metrics-server
   targetNamespace: kube-system
   values:


### PR DESCRIPTION
원본 Helm 이력 추적을 위해 spec.chart.origin 추가

chart의 repository를 harbor로 변경하는 커밋 바로 이전 상태를 기준으로 작업
- repository 변경 commit: 70fe569814e30cdb955c8f0330e29117a6d37397
- 기준으로 한 commit: 03c52f6265be3374870c4d6e65086336ede8f50a
