### PR TITLE
lma: user helm chart's default tag for kube-state-metrics image

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -342,7 +342,6 @@ spec:
     image:
       registry: harbor-cicd.taco-cat.xyz
       repository: tks/kube-state-metrics
-      tag: 1.9.7-debian-10-r143
     nodeSelector: {} # TO_BE_FIXED
   wait: true
 ---


### PR DESCRIPTION
kube-state-metrics 이미지를 별도로 정의하지 않고 Helm 차트 기본 값을 그대로 사용합니다.