### PR TITLE
cluster-api-aws: change default POD CIDR

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -21,7 +21,7 @@ spec:
       region: TO_BE_FIXED
       kubernetesVersion: v1.22.5
       podCidrBlocks:
-      - 10.10.0.0/16
+      - 192.168.0.0/16
       bastion:
         enabled: true
         instanceType: t3.micro


### PR DESCRIPTION
CAPA 클러스터 POD CIDR 기본 값을 192.168.0.0/16 으로 변경합니다.