### PR TITLE
ingress-nginx: remove image digest

### DIFF
--- a/tks-cluster/base/resources.yaml
+++ b/tks-cluster/base/resources.yaml
@@ -88,10 +88,13 @@ spec:
       image:
         registry: harbor-cicd.taco-cat.xyz
         image: tks/controller
-      patch:
-        image:
-          registry: harbor-cicd.taco-cat.xyz
-          image: tks/kube-webhook-certgen
+        digest: ""
+      admissionWebhooks:
+        patch:
+          image:
+            registry: harbor-cicd.taco-cat.xyz
+            image: tks/kube-webhook-certgen
+            digest: ""
       replicaCount: 2
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
ingess 관련 이미지 digest 값을 제거해서 공식 이미지 저장소가 아닌 다른 저장소의 이미지 사용이 가능하도록 변경하였습니다.