### PR TITLE
add ack for s3

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -93,3 +93,49 @@ spec:
         encrypted: "true"
 
   wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: aws-ack-s3
+  name: aws-ack-s3
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
+    name: s3-chart 
+    version: v1.0.3
+  releaseName: s3-chart 
+  targetNamespace: taco-system
+  values:
+    image:
+      repository: harbor-cicd.taco-cat.xyz/tks/s3-controller  #public.ecr.aws/aws-controllers-k8s/s3-controller
+      tag: v1.0.3
+    aws:
+      region: us-west-2
+    deployment:
+      nodeSelector:
+        kubernetes.io/os: linux
+        taco-lma: enabled
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: ack-resources
+  name: ack-resources
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
+    name: ack-resources
+    version: v1.0.0
+  releaseName: ack-resources
+  targetNamespace: taco-system
+  values:
+    s3:
+      enabled: true
+      name: TO_BE_FIXED

--- a/tks-cluster/infra/aws/site-values.yaml
+++ b/tks-cluster/infra/aws/site-values.yaml
@@ -31,3 +31,10 @@ charts:
         taco-lma: enabled
         servicemesh: enabled
         taco-ingress-gateway: enabled
+- name: ack-resources
+  override:
+    s3:
+      enabled: true
+      name:
+      - tks_thanos_$(clusterName)
+      - tks_loki_$(clusterName)


### PR DESCRIPTION
s3자원에 대한 선언적 관리를 위한 ACK를 추가합니다.

모두 함께 merge되어야 함
- helm: https://github.com/openinfradev/helm-charts/pull/173
- decapod-base: https://github.com/openinfradev/decapod-base-yaml/pull/209
- decapod-site: https://github.com/openinfradev/decapod-site/pull/121
- tks-flow: https://github.com/openinfradev/tks-flow/pull/150