### PR TITLE
primary cluster 체계를 위한 기본값 변경

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -768,7 +768,7 @@ spec:
       namespace: lma
       prometheus:
         enabled: true
-        url: "thanos-query.lma:9090"
+        url: "lma-prometheus.lma:9090"
       loki:
         enabled: true
         url: "loki-loki-distributed-gateway.lma"

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -22,6 +22,7 @@ global:
 
   lokiHost: loki-loki-distributed-gateway
   lokiPort: 80
+  grafanaDatasourceMetric: lma-prometheus.lma:9090
 
 charts:
 - name: prometheus-operator
@@ -140,7 +141,7 @@ charts:
     serviceMonitor.kubelet.interval: $(serviceScrapeInterval)
     serviceMonitor.istio.interval: $(serviceScrapeInterval)
     serviceMonitor.jaeger.interval: $(serviceScrapeInterval)
-    grafanaDatasource.prometheus.url: "lma-prometheus.lma:9090"
+    grafanaDatasource.prometheus.url: $(grafanaDatasourceMetric)
     # grafanaDatasource.prometheus.url: "thanos-query.lma:9090"
     grafanaDatasource.loki.url: $(lokiHost):$(lokiPort)
 


### PR DESCRIPTION
- 현재: grafana → thanos 구조를
- grafana → prometheus 구조로 바꿔줘야함
- 다음 변수를 사용하여 global에서 지정하여 사용
  - grafanaDatasourceMetric