### PR TITLE
ACK: update bucket name

### DIFF
--- a/tks-cluster/infra/aws/site-values.yaml
+++ b/tks-cluster/infra/aws/site-values.yaml
@@ -36,5 +36,5 @@ charts:
     s3:
       enabled: true
       name:
-      - tks_thanos_$(clusterName)
-      - tks_loki_$(clusterName)
+      - tks-thanos
+      - tks-loki


### PR DESCRIPTION
bucket 이름을 고정으로 변경
현재 primary 구조에서는 organization별 bucket을 생성하고 (현재상황) organization은 계정과 같은 개념이므로 고정명으로 사용가능
추후 organization을 논리적 개념으로 가져가면서 하나의 계정에 여러개 생성가능하도록 하면 이에 대한 수정이 필요한데 현재 organization을 전달하므로 그냥 사용하면 될듯 