### PR TITLE
tks-cluster: ingress-nginx: remove unnecessary service port

### DIFF
--- a/tks-cluster/base/resources.yaml
+++ b/tks-cluster/base/resources.yaml
@@ -119,8 +119,6 @@ spec:
         proxy-body-size: "10m"
       hostPort:
         enabled: true
-    tcp:
-      "10254": 10254:healthz
   wait: true
 # ---
 # apiVersion: helm.fluxcd.io/v1


### PR DESCRIPTION
불필요하게 정의된 포트 (10254)를 삭제합니다. 