### PR TITLE
tks-cluster: aws: update k8s version to v1.25.9

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -19,7 +19,7 @@ spec:
     cluster:
       name: TO_BE_FIXED
       region: TO_BE_FIXED
-      kubernetesVersion: v1.22.5
+      kubernetesVersion: v1.25.9
       podCidrBlocks:
       - 192.168.0.0/16
       bastion:


### PR DESCRIPTION
Cluster API Provider AWS의 클러스터 버전 기본 값을 v1.25.9 로 변경합니다.