### PR TITLE
add upstream cluster-autoscaler chart

### DIFF
--- a/tks-cluster/base/resources.yaml
+++ b/tks-cluster/base/resources.yaml
@@ -164,6 +164,42 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
+    name: k8s-cluster-autoscaler
+  name: k8s-cluster-autoscaler
+spec:
+  helmVersion: v3
+  chart:
+    type: helmrepo
+    repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
+    name: cluster-autoscaler
+    version: 9.28.0
+    origin: https://kubernetes.github.io/autoscaler
+  releaseName: cluster-autoscaler
+  targetNamespace: kube-system
+  values:
+  image:
+    tag: TO_BE_FIXED
+  awsRegion: TO_BE_FIXED
+  autoDiscovery:
+    clusterName: TO_BE_FIXED
+  cloudProvider: aws
+  rbac:
+   serviceAccount:
+     create: false
+     name: "cluster-autoscaler"
+  extraArgs:
+    expander: priority
+  expanderPriorities:
+    10:
+      - .*-taco
+    50:
+      - .*-normal
+  wait: true
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
     name: cluster-autoscaler
   name: cluster-autoscaler
 spec:

--- a/tks-cluster/base/site-values.yaml
+++ b/tks-cluster/base/site-values.yaml
@@ -11,6 +11,14 @@ charts:
 - name: ingress-nginx
   override:
 
+- name: k8s-cluster-autoscaler
+  override:
+    image:
+      tag: v1.25.1
+    awsRegion: ap-northeast-2
+    autoDiscovery:
+      clusterName: $(clusterName)
+
 - name: cluster-autoscaler
   override:
     discoveryNamespace: $(clusterName)


### PR DESCRIPTION
cluster-autoscaler Helm 차트(https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)를 추가합니다.

cluster-autoscaler 적용 당시에 cluster-api 클라우드 프로바이더 구성의 경우 Helm 차트 지원이 미흡해서 별도 Helm 차트를 만들어서 사용해었고 (https://github.com/openinfradev/helm-charts/tree/main/cluster-autoscaler) aws 클라우드 프로바이더 사용을 위해 추가하는 것입니다.

기존 cluster-autoscaler 차트와 이름이 겹치기 때문에 항목 이름을 k8s-cluster-autoscaler로 사용하였습니다.