### PR TITLE
prometheus: override alertmanager config for multiple routes

### DIFF
--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -57,6 +57,7 @@ charts:
 
     # Define for storing alert
     alertmanager.alertmanagerSpec.retention: 120h
+    alertmanager.config.route.routes: []
 
 - name: kube-state-metrics
   override:


### PR DESCRIPTION
alertmanager 에서 멀티 라우트 삭제하면서 발생한 버그해결