### PR TITLE
minio: add default ilm

### DIFF
--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -158,20 +158,25 @@ charts:
 - name: minio
   override:
     users:
-      - accessKey: $(defaultUser)
-        secretKey: $(defaultPassword)
-        policy: consoleAdmin
+    - accessKey: $(defaultUser)
+      secretKey: $(defaultPassword)
+      policy: consoleAdmin
     buckets:
-      - name: thanos
-        policy: public
-        purge: false
-        versioning: true
-        objectlocking: false
-      - name: loki
-        policy: public
-        purge: false
-        versioning: true
-        objectlocking: false
+    - name: thanos
+      policy: public
+      purge: false
+      versioning: true
+      objectlocking: false
+    - name: loki
+      policy: public
+      purge: false
+      versioning: true
+      objectlocking: false
+    customCommands:
+    - ilm rule add --expire-days 90 myminio/thanos
+    - ilm rule add --expire-days 15 myminio/loki
+    - ilm ls myminio/thanos
+    - ilm ls myminio/loki
     persistence.storageClass: $(storageClassName)
     persistence.accessMode: ReadWriteOnce
     persistence.size: 20Gi


### PR DESCRIPTION
loki에 저장되는 객체에대한 만료를 설정합니다.
- thanos: 90일
- loki: 15일