### PR TITLE
fluent-resource: using fluentbit agent - v2.1.4

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -697,7 +697,7 @@ spec:
         tag: v0.1.1
       fluentbit:
         repository: harbor-cicd.taco-cat.xyz/tks/fluentbit
-        fluentbit.tag: 25bc31cd4333f7f77435561ec70bc68e0c73a194
+        fluentbit.tag: v2.1.4
       elasticsearchTemplates:
         repository: harbor-cicd.taco-cat.xyz/tks/curl
         tag: latest


### PR DESCRIPTION
fluentbit agent를 최신으로 올려줍니다.
- 기존 v1.8 
- 신규 v2.1

참고로 기존 이미지에는 kst 지원을 위한 parser를 추가했었으나 (i*k 지원)
현재 해당 내역이 필요치 않은 관계로 일단 fluentbit operator의 공식 이미지를 사용