### PR TITLE
prepare-etcd-secret: apply the label changes after v1.20

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1133,13 +1133,18 @@ spec:
       client_certfile: peer.crt
       client_keyfile: peer.key
     # master node의 label을 환경에 맞게 적어야함
-    # ex) "node-role.kubernetes.io/master": ""
-    nodeSelector: {} # TO_BE_FIXED
-    # master node에 taint가 있는 경우 필요
-    # ex) - key: "node-role.kubernetes.io/master"
-    #       effect: "NoSchedule"
-    #       operator: "Exists"
-    tolerations: [] # TO_BE_FIXED
+    # ex) 1.20< "node-role.kubernetes.io/master": ""
+    #     >1.20 "node-role.kubernetes.io/control-plane": ""
+    # ref. https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes
+    nodeSelector:
+      "node-role.kubernetes.io/control-plane": ""
+    tolerations:
+      - key: "node-role.kubernetes.io/control-plane"
+        effect: "NoSchedule"
+        operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+        operator: "Exists"
     deployer: "tks"
 ---
 apiVersion: helm.fluxcd.io/v1


### PR DESCRIPTION
- ref: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.20.md#urgent-upgrade-notes

1.20에서 마스터를 지칭하는 라벨이 바뀌었네요. 
aws에서 eks 위주로 작업하는 현재는 발현되지 않지만 vm에  cluster 설치하면 발생하고 byoh 작업시에도 만나게 될 예정입니다.
이에 따라 수정해 놓는 것이며 **주의 사항으로 site별로 이 값을 다시 override**하고 있는데 이 내용도 과거버전의 라벨을 지칭하고 있습니다.
따라서 필요한 타이밍에는 수정이 필요