### PR TITLE
minio: bugfix for value level

### DIFF
--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -173,10 +173,10 @@ charts:
       versioning: true
       objectlocking: false
     customCommands:
-    - ilm rule add --expire-days 90 myminio/thanos
-    - ilm rule add --expire-days 15 myminio/loki
-    - ilm ls myminio/thanos
-    - ilm ls myminio/loki
+    - command: ilm rule add --expire-days 90 myminio/thanos
+    - command: ilm rule add --expire-days 15 myminio/loki
+    - command: ilm ls myminio/thanos
+    - command: ilm ls myminio/loki
     persistence.storageClass: $(storageClassName)
     persistence.accessMode: ReadWriteOnce
     persistence.size: 20Gi


### PR DESCRIPTION
minio의 post job을 만들기위한 value의 깊이가 다르게 되어 있는 버그 수정