### PR TITLE
minio: change update strategy to avoid competition for pvc

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -923,8 +923,9 @@ spec:
         memory: 1Gi # tunable
       limits:
         memory: 2Gi # tunable
-    # mode: standalone
-    replicas: 1
+    mode: standalone
+    DeploymentUpdate.type: Recreate
+    # replicas: 3
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease


### PR DESCRIPTION
distribute 버전으로는 바로 설치가 안되네요.
이에따라 현재 문제를 일으키는 부분을 해소하는 방향으로 전환