### PR TITLE
kube-prometheus-operator: bumpup due to update function for status

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -10,7 +10,7 @@ spec:
     type: helmrepo
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
-    version: 44.3.1
+    version: 48.3.1
     origin: https://prometheus-community.github.io/helm-charts
   helmVersion: v3
   releaseName: prometheus-operator-crds
@@ -29,7 +29,7 @@ spec:
     type: helmrepo
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
-    version: 44.3.1
+    version: 48.3.1
     origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus-operator
   targetNamespace: lma
@@ -71,29 +71,25 @@ spec:
       enabled: true
       image:
         repository: tks/prometheus-operator
-        tag: v0.52.0
+        tag: v0.66.0
       admissionWebhooks:
         patch:
           image:
             repository: tks/kube-webhook-certgen
-            tag: v1.0
+            tag: v20221220-controller-v1.5.1-58-g787ea74b6
       prometheusConfigReloader:
         image:
           repository: tks/prometheus-config-reloader
-          tag: v0.52.0
+          tag: v0.66.0
       thanosImage:
         repository: tks/thanos
-        tag: v0.30.2
+        tag: v0.31.0
       nodeSelector: {}  # TO_BE_FIXED
       createCustomResource: true
       cleanupCustomResource: true
       cleanupCustomResourceBeforeInstall: true
     prometheus:
       enabled: false
-      prometheusSpec:
-        image:
-          repository: tks/prometheus
-          tag: v2.31.1
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -108,7 +104,7 @@ spec:
     type: helmrepo
     repository: https://harbor-cicd.taco-cat.xyz/chartrepo/tks
     name: kube-prometheus-stack
-    version: 44.3.1
+    version: 48.3.1
     origin: https://prometheus-community.github.io/helm-charts
   releaseName: prometheus
   targetNamespace: lma
@@ -123,7 +119,7 @@ spec:
       alertmanagerSpec:
         image:
           repository: tks/alertmanager
-          tag: v0.23.0
+          tag: v0.25.0
         nodeSelector: {} # TO_BE_FIXED
         retention: TO_BE_FIXED
 
@@ -238,7 +234,7 @@ spec:
       prometheusSpec:
         image:
           repository: tks/prometheus
-          tag: v2.31.1
+          tag: v2.45.0
         retention: TO_BE_FIXED
         storageSpec:
           volumeClaimTemplate:


### PR DESCRIPTION
argocd에서 완료를 파악하지 못하는 이슈 해소를 위한 오퍼레이터 업그레이드

이미지도 모두 harbor에 등록완료

```
docker pull quay.io/prometheus/alertmanager:v0.25.0
docker pull registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
docker pull quay.io/prometheus-operator/prometheus-operator:v0.66.0
docker pull quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0
docker pull quay.io/prometheus/prometheus:v2.45.0
docker pull quay.io/thanos/thanos:v0.31.0
docker tag quay.io/prometheus/alertmanager:v0.25.0 harbor-cicd.taco-cat.xyz/tks/alertmanager:v0.25.0
docker tag registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6 harbor-cicd.taco-cat.xyz/tks/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
docker tag quay.io/prometheus-operator/prometheus-operator:v0.66.0 harbor-cicd.taco-cat.xyz/tks/prometheus-operator:v0.66.0
docker tag quay.io/prometheus-operator/prometheus-config-reloader:v0.66.0 harbor-cicd.taco-cat.xyz/tks/prometheus-config-reloader:v0.66.0
docker tag quay.io/prometheus/prometheus:v2.45.0 harbor-cicd.taco-cat.xyz/tks/prometheus:v2.45.0
docker tag quay.io/thanos/thanos:v0.31.0 harbor-cicd.taco-cat.xyz/tks/thanos:v0.31.0
docker push harbor-cicd.taco-cat.xyz/tks/alertmanager:v0.25.0
docker push harbor-cicd.taco-cat.xyz/tks/kube-webhook-certgen:v20221220-controller-v1.5.1-58-g787ea74b6
docker push harbor-cicd.taco-cat.xyz/tks/prometheus-operator:v0.66.0
docker push harbor-cicd.taco-cat.xyz/tks/prometheus-config-reloader:v0.66.0
docker push harbor-cicd.taco-cat.xyz/tks/prometheus:v2.45.0
docker push harbor-cicd.taco-cat.xyz/tks/thanos:v0.31.0