### PR TITLE
add tks-admin-tools group

### DIFF
--- a/tks-admin-tools/base/kustomization.yaml
+++ b/tks-admin-tools/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - resources.yaml
+
+transformers:
+  - site-values.yaml

--- a/tks-admin-tools/base/resources.yaml
+++ b/tks-admin-tools/base/resources.yaml
@@ -1,0 +1,188 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: keycloak
+  name: keycloak
+spec:
+  chart:
+    type: helmrepo
+    repository: https://harbor.taco-cat.xyz/chartrepo/tks
+    name: keycloak
+    version: 15.1.6
+    origin: https://github.com/bitnami/charts/tree/main/bitnami/keycloak
+  releaseName: keycloak
+  targetNamespace: keycloak
+  values:
+    global:
+      storageClass: "taco-storage"
+    auth:
+      adminUser: "admin"
+      adminPassword: password
+    proxy: edge
+    httpRelativePath: "/auth/"
+    production: true
+    replicaCount: 1  # tunable
+    ingress:
+      enabled: true
+      ingressClassName: nginx  # tunable
+      hostname: TO_BE_FIXED
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-buffer-size: 20k
+        acme.cert-manager.io/http01-edit-in-place: "true"
+        cert-manager.io/cluster-issuer: http0issuer
+      tls: true
+      selfSigned: false
+    cache:
+      enabled: true
+      stackName: kubernetes
+    postgresql:
+      enabled: false
+    externalDatabase:
+      host: "postgresql.tks-db.svc"  # tunable
+      port: 5432
+      password: password
+    readinessProbe:
+      failureThreshold: 10
+    extraEnvVars:
+      - name: QUARKUS_TRANSACTION_MANAGER_ENABLE_RECOVERY
+        value: "true"
+
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: tks-api
+  name: tks-api
+spec:
+  chart:
+    type: helmrepo
+    repository: https://harbor.taco-cat.xyz/chartrepo/tks
+    name: tks-api
+    version: 0.1.2
+    origin: https://openinfradev.github.io/helm-repo
+  releaseName: tks-api
+  targetNamespace: tks
+  values:
+    gitBaseUrl: https://github.com
+    gitAccount: decapod10
+    db:
+      dbHost: postgresql.tks-db.svc
+      adminUser: postgres
+      adminPassword: password  # tunable
+      dbUser: tksuser
+      dbPassword: password  # tunable
+    tksapi:
+      replicaCount: 1
+      image:
+        repository: harbor.taco-cat.xyz/tks/tks-api
+        tag: v3.0.1
+      # Master org's admin password
+      tksAccount:
+        password: admin  # tunable
+      args:
+        imageRegistryUrl: "harbor.taco-cat.xyz/appserving"  # tunable
+        harborPwSecret: "harbor-core"
+        gitRepositoryUrl: "github.com/openinfradev"  # tunable
+        keycloakAddress: http://keycloak.keycloak.svc:80/auth
+    tksbatch:
+      replicaCount: 1
+      image:
+        repository: harbor.taco-cat.xyz/tks/tks-batch
+        tag: v3.0.0
+    tksconsole:
+      replicaCount: 1
+      image:
+        repository: harbor.taco-cat.xyz/tks/tks-console
+        tag: v3.0.1
+
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: harbor
+  name: harbor
+spec:
+  chart:
+    type: helmrepo
+    repository: https://harbor.taco-cat.xyz/chartrepo/tks
+    name: harbor
+    version: 1.11.0
+    origin: https://github.com/goharbor/harbor-helm
+  releaseName: harbor
+  targetNamespace: harbor
+  values:
+    expose:
+      tls:
+        certSource: secret
+        secret:
+          secretName: "harbor.taco-cat-tls"  # tunable
+      ingress:
+        hosts:
+          core: TO_BE_FIXED
+        className: "nginx"  # tunable
+        annotations:
+          cert-manager.io/cluster-issuer: http0issuer
+          acme.cert-manager.io/http01-edit-in-place: "true"
+    externalURL: TO_BE_FIXED
+    #######################################################
+    ## all values under persistence are tunable (for HA) ##
+    #######################################################
+    persistence:
+      persistentVolumeClaim:
+        registry:
+          storageClass: taco-storage
+          accessMode: ReadWriteOnce
+          size: 200Gi
+        chartmuseum:
+          storageClass: taco-storage
+          accessMode: ReadWriteOnce
+          size: 20Gi
+        jobservice:
+          jobLog:
+            storageClass: taco-storage
+            accessMode: ReadWriteOnce
+          scanDataExports:
+            storageClass: taco-storage
+            accessMode: ReadWriteOnce
+        redis:
+          storageClass: taco-storage
+          accessMode: ReadWriteOnce
+        trivy:
+          storageClass: taco-storage
+    database:
+      type: external
+      external:
+        host: "postgresql.tks-db.svc"  # tunable
+        port: "5432"
+        username: "harbor"
+        password: password  # tunable
+        existingSecret: ""
+        # "disable" - No SSL
+        # "require" - Always SSL (skip verification)
+        # "verify-ca" - Always SSL (verify that the certificate presented by the
+        # server was signed by a trusted CA)
+        # "verify-full" - Always SSL (verify that the certification presented by the
+        # server was signed by a trusted CA and the server host name matches the one
+        # in the certificate)
+        sslmode: "require"
+    notary:
+      enabled: false
+    cache:
+      enabled: true
+    core:
+      replicas: 1  # tunable
+    jobservice:
+      replicas: 1  # tunable
+    registry:
+      replicas: 1  # tunable
+    chartmuseum:
+      replicas: 1  # tunable
+    trivy:
+      replicas: 1  # tunable
+    portal:
+      replicas: 1  # tunable
+    harborAdminPassword: password  # tunable

--- a/tks-admin-tools/base/site-values.yaml
+++ b/tks-admin-tools/base/site-values.yaml
@@ -1,0 +1,91 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: site
+
+global:
+  dbHost: ${DATABASE_HOST}
+  commonPassword: ${COMMON_PASSWORD}
+  storageClass: ${STORAGE_CLASS}
+  storageClassHa: ${STORAGE_CLASS_HA}
+
+charts:
+- name: keycloak
+  override:
+    global.storageClass: $(storageClass)
+    auth.adminPassword: $(commonPassword)
+    ingress.enabled: true
+    ingress.hostname: TO_BE_FIXED
+    externalDatabase.host: $(dbHost)
+    externalDatabase.password: $(commonPassword)
+
+- name: tks-api
+  override:
+    gitBaseUrl: https://github.com
+    gitAccount: decapod10
+    db:
+      dbHost: $(dbHost)
+      adminPassword: $(commonPassword)
+      dbUser: tksuser
+      dbPassword: $(commonPassword)
+    tksapi:
+      replicaCount: 1
+      tksAccount:
+        password: $(commonPassword)
+      args:
+        imageRegistryUrl: "harbor.taco-cat.xyz/appserving"
+        gitRepositoryUrl: "github.com/openinfradev"
+        keycloakAddress: http://keycloak.keycloak.svc:80/auth
+    tksbatch:
+      replicaCount: 1
+    tksconsole:
+      replicaCount: 1
+
+- name: harbor
+  override:
+    expose:
+      ingress:
+        hosts:
+          core: TO_BE_FIXED
+        className: "nginx"  
+    externalURL: TO_BE_FIXED
+    persistence:
+      persistentVolumeClaim:
+        registry:
+          storageClass: $(storageClassHa)
+          accessMode: ReadWriteMany
+          size: 200Gi
+        chartmuseum:
+          storageClass: $(storageClassHa)
+          accessMode: ReadWriteMany
+          size: 20Gi
+        jobservice:
+          jobLog:
+            storageClass: $(storageClassHa)
+            accessMode: ReadWriteMany
+          scanDataExports:
+            storageClass: $(storageClassHa)
+            accessMode: ReadWriteMany
+        redis:
+          storageClass: $(storageClass)
+          accessMode: ReadWriteOnce
+        trivy:
+          storageClass: $(storageClass)
+    database:
+      type: external
+      external:
+        host: $(dbHost)  
+        password: $(commonPassword)
+    core:
+      replicas: 2  
+    jobservice:
+      replicas: 2  
+    registry:
+      replicas: 2  
+    chartmuseum:
+      replicas: 2  
+    trivy:
+      replicas: 2  
+    portal:
+      replicas: 2  
+    harborAdminPassword: $(commonPassword)

--- a/tks-admin-tools/image/image-values.yaml
+++ b/tks-admin-tools/image/image-values.yaml
@@ -1,0 +1,78 @@
+apiVersion: openinfradev.github.com/v1
+kind: HelmValuesTransformer
+metadata:
+  name: image
+
+global:
+  registry: harbor.taco-cat.xyz
+
+charts:
+- name: keycloak
+  override:
+    image:
+      registry: $(registry)
+      repository: bitnami/keycloak
+      tag: 21.1.2-debian-11-r0
+- name: tks-api
+  override:
+    tks-api:
+      image:
+        repository: $(registry)/tks/tks-api
+        tag: v3.0.1
+    tksbatch:
+      image:
+        repository: $(registry)/tks/tks-batch
+        tag: v3.0.0
+    tksconsole:
+      image:
+        repository: $(registry)/tks/tks-console
+        tag: v3.0.1
+- name: harbor
+  override:
+    portal:
+      image:
+        repository: $(registry)/goharbor/harbor-portal
+        tag: v2.7.0
+    core:
+      image:
+        repository: $(registry)/goharbor/harbor-core
+        tag: v2.7.0
+    jobservice:
+      image:
+        repository: $(registry)/goharbor/harbor-jobservice
+        tag: v2.7.0
+    registry:
+      registry:
+        image:
+          repository: $(registry)/goharbor/registry-photon
+          tag: v2.7.0
+      controller:
+        image:
+          repository: $(registry)/goharbor/harbor-registryctl
+          tag: v2.7.0
+    chartmuseum:
+      image:
+        repository: $(registry)/goharbor/chartmuseum-photon
+        tag: v2.7.0
+    trivy:
+      image:
+        repository: $(registry)/goharbor/trivy-adapter-photon
+        tag: v2.7.0
+    notary:
+      server:
+        image:
+          repository: $(registry)/goharbor/notary-server-photon
+          tag: v2.7.0
+      signer:
+        image:
+          repository: $(registry)/goharbor/notary-signer-photon
+          tag: v2.7.0
+    redis:
+      internal:
+        image:
+          repository: $(registry)/goharbor/redis-photon
+          tag: v2.7.0
+    exporter:
+      image:
+        repository: $(registry)/goharbor/harbor-exporter
+        tag: v2.7.0


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/861

일단 요렇게 올렸는데, 몇가지 의견을 구할 점들이 있습니다.

1. site-values.yaml 파일의 필요 여부: 만들다 보니 resources.yaml 중 어떤 내용들이 site-values로 가야하는지 상당히 애매하군요. 기본적으로 base의 내용은 다 override할 수 있다고 생각하고 바로 site-template 등에서 직접 override하는 게 나은 건 아닌가 하는 생각도 들었습니다.  opensource 일 때는 사용자가 참고할 수 있는 sample 용도의 성격이 있었으나, 지금처럼 우리가 직접 site-template을 관리하는 상황에서는 그 필요성이 크게 없어진 것 같다는 느낌입니다. 

2. password 값 표시 위치: helm chart 는 공적인 성격의 repo다 보니 password 표시는 자제하자고 태규님께도 코멘트 드렸지만, 실제 값이 들어가는 decapod 입장에서는 어딘가에 실제 값이 들어가야 하는데, 그게 base에서부터? 또는 site 에만? 하는 고민이 되었는데, 일단은 기존 파일들과 비슷하게 base에 다 넣긴 했습니다. 

3. site-values.yaml 과 실제 site-template 에서의 작성 규칙
"a.b.c" 처럼 한줄로 표시하는 형식과 base와 동일하게 block 형식으로 작성하는 형식 중 최종 합의된 rule이 뭐였죠? 전에 동규님께서 이부분 파싱 작업할 때 이슈가 있어 앞으로는 어떻게 하자고 합의했던 걸로 기억해서 다시 여쭤봅니다. 

의견 부탁드립니다.

decapod-site PR: https://github.com/openinfradev/decapod-site/pull/177