### PR TITLE
make the upstream cluster-autoscaler chart common to all

### DIFF
--- a/tks-cluster/base/resources.yaml
+++ b/tks-cluster/base/resources.yaml
@@ -168,42 +168,6 @@ apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
 metadata:
   labels:
-    name: k8s-cluster-autoscaler
-  name: k8s-cluster-autoscaler
-spec:
-  helmVersion: v3
-  chart:
-    type: helmrepo
-    repository: https://harbor.taco-cat.xyz/chartrepo/tks
-    name: cluster-autoscaler
-    version: 9.28.0
-    origin: https://kubernetes.github.io/autoscaler
-  releaseName: cluster-autoscaler
-  targetNamespace: kube-system
-  values:
-    image:
-      tag: TO_BE_FIXED
-    awsRegion: TO_BE_FIXED
-    autoDiscovery:
-      clusterName: TO_BE_FIXED
-    cloudProvider: aws
-    rbac:
-     serviceAccount:
-       create: false
-       name: "cluster-autoscaler"
-    extraArgs:
-      expander: priority
-    expanderPriorities:
-      "10":
-        - .*-taco
-      "50":
-        - .*-normal
-  wait: true
----
-apiVersion: helm.fluxcd.io/v1
-kind: HelmRelease
-metadata:
-  labels:
     name: cluster-autoscaler
   name: cluster-autoscaler
 spec:
@@ -212,15 +176,14 @@ spec:
     type: helmrepo
     repository: https://harbor.taco-cat.xyz/chartrepo/tks
     name: cluster-autoscaler
-    version: 0.2.0
-    origin: https://openinfradev.github.io/helm-repo
+    version: 9.29.4
+    origin: https://kubernetes.github.io/autoscaler
   releaseName: cluster-autoscaler
   targetNamespace: kube-system
   values:
-    separateMgmtClusterEnabled: true
-    discoveryNamespace: TO_BE_FIXED
-    discoveryClusterName: TO_BE_FIXED
-    mgmtKubeconfigSecretName: mgmt-kubeconfig
+    image:
+      tag: TO_BE_FIXED
+    cloudProvider: TO_BE_FIXED
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1


### PR DESCRIPTION
Mananged Control plane과 EKS 각각 분리해서 사용하던 cluster-autoscaler 차트를 업스트림 차트(https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler)로 통일합니다.

- 이력
  - Managed controle plane: cluster-api 프로바이더 지원을 위한 내역이 부족하여 업스트림과 별도로 차트를 만들어서 사용 (https://github.com/openinfradev/helm-charts/tree/main/cluster-autoscaler)
  - EKS: AWS 프로바이더를 사용하여 적용

최신 버전에서는 cluster-api 프로바이더를 위해 필요한 부분도 모두 포함되어 있어 업스트림 차트를 공통적으로 사용하도록 수정