### PR TITLE
lma-addons: bumpup

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -753,7 +753,7 @@ spec:
     type: helmrepo
     repository: https://harbor.taco-cat.xyz/chartrepo/tks
     name: lma-addons
-    version: 1.8.5
+    version: 1.8.6
     origin: https://openinfradev.github.io/helm-repo
   releaseName: addons
   targetNamespace: lma


### PR DESCRIPTION
lma-addons chart에 hardfix된 네임스페이스 지정가능하도록 수정내역 반영

급하지는 않습니다. lma를 lma가 아닌 다른 네임스페이스로 설치하려면 필요합니다.