### PR TITLE
Bugfix skb

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -919,8 +919,8 @@ spec:
       limits:
         memory: 2Gi # tunable
     mode: standalone
-    deployment.updateStrategy: Recreate
-    # replicas: 3
+    DeploymentUpdate:
+      type: Recreate
 ---
 apiVersion: helm.fluxcd.io/v1
 kind: HelmRelease
@@ -958,9 +958,8 @@ spec:
       nodeSelector: {}
       service:
         type: TO_BE_FIXED
-        http:
-          port: 9090
-          nodePort: TO_BE_FIXED
+        nodePorts:
+          http: TO_BE_FIXED
       config: |-
         type: IN-MEMORY
         config:

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -196,7 +196,8 @@ charts:
     query.dnsDiscovery.sidecarsService: null
     queryFrontend.nodeSelector: $(nodeSelector)
     queryFrontend.service.type: NodePort
-    queryFrontend.service.http.nodePort: 30007
+    queryFrontend.service.nodePorts.http: 30005
+
     bucketweb.nodeSelector: $(nodeSelector)
     compactor.nodeSelector: $(nodeSelector)
     storegateway.nodeSelector: $(nodeSelector)


### PR DESCRIPTION
1. thanos queryfrontend 서비스의 노드포트 지정관련 코드속의 유령을 잡았는데 역시 착각 이었음
- service.nodeports.http 라니...

2. minio의 재시작 정책관련 이슈도 찾았음
- ``` a.b = x ```와 
```
a:
  b: x
```
가 다르게 적용되는 케이스였음, kustomize와 helm value 지정을 통과하면서 이걸 버그라과 봐야할지 의도된 것인지 모르겠음  

혼선을 없애기 위해 site에 잘못된 부분도 바로잡음..  https://github.com/openinfradev/decapod-site/pull/211