### PR TITLE
노드 매트릭에 호스트명 추가

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -371,6 +371,11 @@ spec:
     prometheus:
       monitor:
         enabled: true
+        relabelings:
+        - action: replace
+          sourceLabels:
+          - __meta_kubernetes_endpoint_node_name
+          targetLabel: hostname
     extraArgs:
     - --no-collector.hwmon
     tolerations:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -809,7 +809,7 @@ spec:
       kubeStateMetrics:
         enabled: true
       nodeExporter:
-        enabled: true
+        enabled: false
       pushgateway:
         enabled: true
       kubelet:


### PR DESCRIPTION
node exporter에서 수집하는 데이터에 호스트명을 추가합니다.
이렇게 되면 추후 노드관련 매트릭 (ex. node_cpu_throttle ?, node_load_1....)에는 라벨들 중 hostname이라는 필드에 해당 머신의 hostname이 들어갑니다. 
hostname을 영구적으로 적용한게 아니라면 이에 따른 시계열 데이터 분리(기존 호스트명 데이터와 바뀐 호스트명 데이터)가 있을수 있습니다.
이후 작업으로 기존에 instance를 기준으로 호스트를 판단했던 grafana dashboard들이 추가된 라벨을 사용하도록 수정하는 것을 권장합니다.

Base의 수정이므로 이것만 반영되면 이후 만들어지는 모든 클러스터에 반영됩니다.