### PR TITLE
update chart version cluster-api-aws

### DIFF
--- a/tks-cluster/infra/aws/resources.yaml
+++ b/tks-cluster/infra/aws/resources.yaml
@@ -11,7 +11,7 @@ spec:
     type: helmrepo
     repository: https://harbor.taco-cat.xyz/chartrepo/tks
     name: cluster-api-aws
-    version: 0.10.0
+    version: 0.10.1
   releaseName: cluster-api-aws
   targetNamespace: argo
   values:


### PR DESCRIPTION
psnm 지원을 위해 cluster-api-aws chart 버전을 업데이트 합니다.

helm-chart PR
 . https://github.com/openinfradev/helm-charts/pull/221