### PR TITLE
typo-fix: policy-serving: change the namespace for decapod randering

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -1237,7 +1237,7 @@ spec:
     name: ack-resources
     version: v1.0.2
   releaseName: lma-bucket
-  targetNamespace: lma
+  targetNamespace: taco-system
   values:
     tks:
       iamRoles: [] #arn:aws:iam::482246953094:role/control-plane.cluster-api-provider-aws.sigs.k8s.io
@@ -1260,7 +1260,7 @@ spec:
     name: opa-scorecard
     version: 0.1.0
   releaseName: opa-exporter
-  targetNamespace: taco-system
+  targetNamespace: lma
   values:
     gatekeeper:
       namespace: gatekeeper-system


### PR DESCRIPTION
이전 commit에서 위치가 잘못되어 다시 pr

policy-serving: change the namespace for decapod randering