### PR TITLE
fluentbit: use upgraded version from 2.2 to 3.0

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -693,7 +693,7 @@ spec:
         tag: v0.1.1
       fluentbit:
         repository: harbor.taco-cat.xyz/tks/fluent-bit
-        tag: v2.2.0
+        tag: v3.0.4
       elasticsearchTemplates:
         repository: harbor.taco-cat.xyz/tks/curl
         tag: latest


### PR DESCRIPTION
fluentbit 3.0 버전을 사용합니다.

현재 2.2 버전에 버그가 있는듯 합니다. 긴급패치까지 포함해야됨.