### PR TITLE
tks-policy: add ratify for supporting valication upon SBOM.

### DIFF
--- a/policy/base/resources.yaml
+++ b/policy/base/resources.yaml
@@ -36,3 +36,31 @@ spec:
   releaseName: policy-resources
   targetNamespace: gatekeeper-system
   values: {}
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  labels:
+    name: ratify
+  name: ratify
+spec:
+  chart:
+    type: helmrepo
+    repository: https://harbor.taco-cat.xyz/chartrepo/tks
+    name: ratify
+    version: 1.13.0
+    origin: https://github.com/ratify-project/ratify/tree/v1.2.0/charts/ratify
+  helmVersion: v3
+  releaseName: ratify
+  targetNamespace: gatekeeper-system
+  values: 
+    oras:
+      useHttp: true
+    provider:
+      tls:
+        skipVerify: true
+    featureFlags:
+      RATIFY_CERT_ROTATION: true
+    sbom:
+      enabled: true
+---

--- a/policy/base/site-values.yaml
+++ b/policy/base/site-values.yaml
@@ -25,3 +25,36 @@ charts:
     enableDeleteOperations: true
 
 - name: policy-resources
+
+- name: ratify
+  override:
+    sbom:
+      disallowedLicenses:
+      - "GPL-2.0-only"
+      - "MPL"
+      disallowedPackages:
+      - name: "busybox"
+        version: "1.36.1-r28"
+    notationCerts:
+    # https://github.com/ratify-project/ratify/blob/dev/test/testdata/notation.crt
+    - |-
+      -----BEGIN CERTIFICATE-----
+      MIIDQzCCAiugAwIBAgIUDxHQ9JxxmnrLWTA5rAtIZCzY8mMwDQYJKoZIhvcNAQEL
+      BQAwKTEPMA0GA1UECgwGUmF0aWZ5MRYwFAYDVQQDDA1SYXRpZnkgU2FtcGxlMB4X
+      DTIzMDYyOTA1MjgzMloXDTMzMDYyNjA1MjgzMlowKTEPMA0GA1UECgwGUmF0aWZ5
+      MRYwFAYDVQQDDA1SYXRpZnkgU2FtcGxlMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+      MIIBCgKCAQEAshmsL2VM9ojhgTVUUuEsZro9jfI27VKZJ4naWSHJihmOki7IoZS8
+      3/3ATpkE1lGbduJ77M9UxQbEW1PnESB0bWtMQtjIbser3mFCn15yz4nBXiTIu/K4
+      FYv6HVdc6/cds3jgfEFNw/8RVMBUGNUiSEWa1lV1zDM2v/8GekUr6SNvMyqtY8oo
+      ItwxfUvlhgMNlLgd96mVnnPVLmPkCmXFN9iBMhSce6sn6P9oDIB+pr1ZpE4F5bwa
+      gRBg2tWN3Tz9H/z2a51Xbn7hCT5OLBRlkorHJl2HKKRoXz1hBgR8xOL+zRySH9Qo
+      3yx6WvluYDNfVbCREzKJf9fFiQeVe0EJOwIDAQABo2MwYTAdBgNVHQ4EFgQUKzci
+      EKCDwPBn4I1YZ+sDdnxEir4wHwYDVR0jBBgwFoAUKzciEKCDwPBn4I1YZ+sDdnxE
+      ir4wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAgQwDQYJKoZIhvcNAQEL
+      BQADggEBAGh6duwc1MvV+PUYvIkDfgj158KtYX+bv4PmcV/aemQUoArqM1ECYFjt
+      BlBVmTRJA0lijU5I0oZje80zW7P8M8pra0BM6x3cPnh/oZGrsuMizd4h5b5TnwuJ
+      hRvKFFUVeHn9kORbyQwRQ5SpL8cRGyYp+T6ncEmo0jdIOM5dgfdhwHgb+i3TejcF
+      90sUs65zovUjv1wa11SqOdu12cCj/MYp+H8j2lpaLL2t0cbFJlBY6DNJgxr5qync
+      cz8gbXrZmNbzC7W5QK5J7fcx6tlffOpt5cm427f9NiK2tira50HU7gC3HJkbiSTp
+      Xw10iXXMZzSbQ0/Hj2BF4B40WfAkgRg=
+      -----END CERTIFICATE-----


### PR DESCRIPTION
SBOM을 통한 정책생성을 위한 모듈(ratify)을 설치합니다.
기존 모듈과 상충은 없음, site-value로 실 적용시 적용할 값의 예시를 정의 (인증서, 검출 룰) 

이를 기반으로 할수 있는 기능예시
- GPL 라이센스 기반 오픈소스사용 금지
- AGPL 라이센스 기반 오픈소스사용 금지
- 특정 오픈소스 사용금지 등..