### PR TITLE
lma: seperate clusterName and clusterDomain explicitly

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -906,7 +906,7 @@ spec:
       registry: harbor.taco-cat.xyz
       repository: tks/thanos
       tag: v0.30.2
-    clusterDomain: $(clusterName)
+    clusterDomain: $(clusterDomain)
     existingObjstoreSecret: TO_BE_FIXED
     query:
       nodeSelector: {}
@@ -1123,7 +1123,7 @@ spec:
   targetNamespace: taco-system
   values:
     global:
-      clusterDomain: $(clusterName)
+      clusterDomain: $(clusterDomain)
       dnsService: coredns
     loki:
       image:
@@ -1202,7 +1202,7 @@ spec:
   targetNamespace: taco-system
   values:
     global:
-      clusterDomain: $(clusterName)
+      clusterDomain: $(clusterDomain)
       dnsService: coredns
     loki:
       image:


### PR DESCRIPTION
clusterName으로 url과 클러스터 표기를 병행했던것을 명확하게 분리
- 현재 클러스터명을 url에 넣지 못하는 이슈가 있어, 이에대한 회피를 통해 잠재적인 에러들을 만들고 있었음